### PR TITLE
[backend]修复保存SVN代码库插件报错 fixed #72

### DIFF
--- a/src/backend/repository/api-repository/src/main/kotlin/com/tencent/devops/repository/pojo/CodeSvnRepository.kt
+++ b/src/backend/repository/api-repository/src/main/kotlin/com/tencent/devops/repository/pojo/CodeSvnRepository.kt
@@ -39,7 +39,7 @@ data class CodeSvnRepository(
     @ApiModelProperty("凭据id", required = true)
     override val credentialId: String,
     @ApiModelProperty("SVN区域", required = true)
-    val region: CodeSvnRegion,
+    val region: CodeSvnRegion? = CodeSvnRegion.TC,
     @ApiModelProperty("svn项目名称", example = "xx/yy_proj", required = true)
     override val projectName: String,
     @ApiModelProperty("用户名", required = true)

--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/dao/RepositoryCodeSvnDao.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/dao/RepositoryCodeSvnDao.kt
@@ -40,7 +40,7 @@ class RepositoryCodeSvnDao {
     fun create(
         dslContext: DSLContext,
         repositoryId: Long,
-        region: CodeSvnRegion,
+        region: CodeSvnRegion?,
         projectName: String,
         userName: String,
         privateToken: String,
@@ -61,7 +61,7 @@ class RepositoryCodeSvnDao {
             )
                 .values(
                     repositoryId,
-                    region.name,
+                    region?.name ?: "",
                     projectName,
                     userName,
                     privateToken,
@@ -87,7 +87,7 @@ class RepositoryCodeSvnDao {
     fun edit(
         dslContext: DSLContext,
         repositoryId: Long,
-        region: CodeSvnRegion,
+        region: CodeSvnRegion?,
         projectName: String,
         userName: String,
         credentialId: String,
@@ -96,7 +96,7 @@ class RepositoryCodeSvnDao {
         val now = LocalDateTime.now()
         with(TRepositoryCodeSvn.T_REPOSITORY_CODE_SVN) {
             dslContext.update(this)
-                .set(REGION, region.name)
+                .set(REGION, region?.name ?: "")
                 .set(PROJECT_NAME, projectName)
                 .set(USER_NAME, userName)
                 .set(UPDATED_TIME, now)

--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/service/RepositoryService.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/service/RepositoryService.kt
@@ -244,7 +244,11 @@ class RepositoryService @Autowired constructor(
                     repository.aliasName,
                     repository.url,
                     record.credentialId,
-                    CodeSvnRegion.valueOf(record.region),
+                    if (record.region.isNullOrBlank()) {
+                        CodeSvnRegion.TC
+                    } else {
+                        CodeSvnRegion.valueOf(record.region)
+                    },
                     record.projectName,
                     record.userName,
                     repository.projectId,


### PR DESCRIPTION
由于SVN插件的区域为空，导致与模型定义出现冲突。 改为允许为空，并设置一个默认值 。该值目前无用，可忽略。