### PR TITLE
升级pipeline-plugin所依赖的jackson-databind版本到2.9.9.2

### DIFF
--- a/src/pipeline-plugin/bksdk/pom.xml
+++ b/src/pipeline-plugin/bksdk/pom.xml
@@ -32,6 +32,7 @@
         <lib.dozer.version>5.5.1</lib.dozer.version>
         <lib.log.version>1.7.21</lib.log.version>
         <lib.jackson.version>2.9.9</lib.jackson.version>
+        <lib.jackson.databind.version>2.9.9.2</lib.jackson.databind.version>
     </properties>
 
     <dependencies>
@@ -66,7 +67,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${lib.jackson.version}</version>
+            <version>${lib.jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
fixed #71 