### PR TITLE
--story=856430647 【M蓝盾&Keystore】蓝盾支持提供支持iOS企业证书的MacOS公共构建集群

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/type/DispatchRouteKeySuffix.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/type/DispatchRouteKeySuffix.kt
@@ -31,5 +31,6 @@ enum class DispatchRouteKeySuffix(val routeKeySuffix: String) {
     DEVCLOUD(".devcloud.public"),
     IDC(".idc.public"),
     GITCI(".gitci.public"),
-    CODECC(".codecc.scan")
+    CODECC(".codecc.scan"),
+    MACOS(".macos")
 }


### PR DESCRIPTION
新增macos的dispatch类型