### PR TITLE
bugfix:修复镜像适用范围(agentType)相关问题 #564

### DIFF
--- a/src/backend/ci/core/store/api-store-image/src/main/kotlin/com/tencent/devops/store/pojo/image/enums/ImageStatusEnum.kt
+++ b/src/backend/ci/core/store/api-store-image/src/main/kotlin/com/tencent/devops/store/pojo/image/enums/ImageStatusEnum.kt
@@ -75,6 +75,8 @@ enum class ImageStatusEnum(val status: Int) {
                 COMMITTING.status,
                 CHECKING.status,
                 TESTING.status,
+                //上架中止应当属于非终止态，需将数据回显至下一次上架
+                GROUNDING_SUSPENSION.status,
                 AUDITING.status,
                 UNDERCARRIAGING.status
             )
@@ -88,7 +90,6 @@ enum class ImageStatusEnum(val status: Int) {
                 CHECK_FAIL.status,
                 AUDIT_REJECT.status,
                 RELEASED.status,
-                GROUNDING_SUSPENSION.status,
                 UNDERCARRIAGED.status
             )
         }

--- a/src/backend/ci/core/store/api-store-image/src/main/kotlin/com/tencent/devops/store/pojo/image/enums/ImageStatusEnum.kt
+++ b/src/backend/ci/core/store/api-store-image/src/main/kotlin/com/tencent/devops/store/pojo/image/enums/ImageStatusEnum.kt
@@ -75,7 +75,7 @@ enum class ImageStatusEnum(val status: Int) {
                 COMMITTING.status,
                 CHECKING.status,
                 TESTING.status,
-                //上架中止应当属于非终止态，需将数据回显至下一次上架
+                // 上架中止应当属于非终止态，需将数据回显至下一次上架
                 GROUNDING_SUSPENSION.status,
                 AUDITING.status,
                 UNDERCARRIAGING.status

--- a/src/backend/ci/core/store/biz-store-image/src/main/kotlin/com/tencent/devops/store/service/image/ImageReleaseService.kt
+++ b/src/backend/ci/core/store/biz-store-image/src/main/kotlin/com/tencent/devops/store/service/image/ImageReleaseService.kt
@@ -29,6 +29,7 @@ package com.tencent.devops.store.service.image
 import com.tencent.devops.common.api.constant.CommonMessageCode
 import com.tencent.devops.common.api.constant.LATEST
 import com.tencent.devops.common.api.exception.DataConsistencyException
+import com.tencent.devops.common.api.exception.InvalidParamException
 import com.tencent.devops.common.api.exception.ParamBlankException
 import com.tencent.devops.common.api.pojo.Result
 import com.tencent.devops.common.api.util.DHUtil
@@ -227,6 +228,12 @@ abstract class ImageReleaseService {
         runCheckPipeline: Boolean = true
     ): Result<String?> {
         logger.info("updateMarketImage userId is :$userId, marketImageUpdateRequest is :$marketImageUpdateRequest")
+        if (marketImageUpdateRequest.agentTypeScope.isEmpty()) {
+            throw InvalidParamException(
+                message = "agentTypeScope cannot be empty",
+                params = arrayOf("agentTypeScope=[]")
+            )
+        }
         val imageCode = marketImageUpdateRequest.imageCode
         val imageTag = marketImageUpdateRequest.imageTag
         // 判断镜像tag是否为latest

--- a/support-files/sql/0004_ci_store-update-table_20191225-1831_mysql.sql
+++ b/support-files/sql/0004_ci_store-update-table_20191225-1831_mysql.sql
@@ -27,7 +27,7 @@ BEGIN
                   WHERE TABLE_SCHEMA = db
                     AND TABLE_NAME = 'T_IMAGE'
                     AND COLUMN_NAME = 'DOCKER_FILE_CONTENT') THEN
-        ALTER TABLE T_IMAGE ADD COLUMN `DOCKER_FILE_CONTENT` text NOT NULL COMMENT 'dockerFile内容';
+        ALTER TABLE T_IMAGE ADD COLUMN `DOCKER_FILE_CONTENT` text COMMENT 'dockerFile内容';
     END IF;
 	
     COMMIT;


### PR DESCRIPTION
bugfix:镜像上架中止后再次上架镜像详情回显中应有上一次适用机器范围 #564
bugfix:上架镜像时适用机器需要有不为空校验 #565