### PR TITLE
feature:实例维护session，timeout数据结构调整

### DIFF
--- a/src/backend/ci/core/common/common-event/src/main/kotlin/com/tencent/devops/common/event/dispatcher/pipeline/mq/MQ.kt
+++ b/src/backend/ci/core/common/common-event/src/main/kotlin/com/tencent/devops/common/event/dispatcher/pipeline/mq/MQ.kt
@@ -185,6 +185,9 @@ object MQ {
     const val EXCHANGE_WEBSOCKET_TMP_FANOUT = "e.websocket.fanout"
     const val ROUTE_WEBSOCKET_TMP_EVENT = "r.websocket.file"
     const val QUEUE_WEBSOCKET_TMP_EVENT = "q.websocket.file"
+    const val EXCHANGE_WEBSOCKET_TRANSFER_FANOUT = "e.websocket.transfer.fanout"
+    const val ROUTE_WEBSOCKET_TRANSFER_EVENT = "r.websocket.transfer.file"
+    const val QUEUE_WEBSOCKET_TRANSFER_EVENT = "q.websocket.transfer.file"
 
     // 工蜂CI请求
     const val EXCHANGE_GITCI_REQUEST_TRIGGER_EVENT = "e.gitci.request.trigger.event"

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/TransferDispatch.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/TransferDispatch.kt
@@ -1,0 +1,42 @@
+package com.tencent.devops.common.websocket.dispatch
+
+import com.tencent.devops.common.event.annotation.Event
+import com.tencent.devops.common.event.dispatcher.EventDispatcher
+import com.tencent.devops.common.event.pojo.pipeline.IPipelineRoutableEvent
+import com.tencent.devops.common.websocket.dispatch.push.TransferPush
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import java.lang.Exception
+
+class TransferDispatch (
+    private val rabbitTemplate: RabbitTemplate
+) : EventDispatcher<TransferPush> {
+    companion object{
+        val logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    override fun dispatch(vararg events: TransferPush) {
+        try {
+            events.forEach { event ->
+                val eventType = event::class.java.annotations.find { s -> s is Event } as Event
+                val routeKey = // 根据 routeKey+后缀 实现动态变换路由Key
+                    if (event is IPipelineRoutableEvent && !event.routeKeySuffix.isNullOrBlank()) {
+                        eventType.routeKey + event.routeKeySuffix
+                    } else {
+                        eventType.routeKey
+                    }
+                logger.info("[${eventType.exchange}|$routeKey|${event.userId}|${event.page}] dispatch the transfer event")
+                rabbitTemplate.convertAndSend(eventType.exchange, routeKey, event) { message ->
+                    when {
+                        event.delayMills!! > 0 -> message.messageProperties.setHeader("x-delay", event.delayMills)
+                        eventType.delayMills > 0 -> // 事件类型固化默认值
+                            message.messageProperties.setHeader("x-delay", eventType.delayMills)
+                    }
+                    message
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Fail to dispatch the event($events)", e)
+        }
+    }
+}

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/TransferDispatch.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/TransferDispatch.kt
@@ -8,10 +8,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import java.lang.Exception
 
-class TransferDispatch (
+class TransferDispatch(
     private val rabbitTemplate: RabbitTemplate
 ) : EventDispatcher<TransferPush> {
-    companion object{
+    companion object {
         val logger = LoggerFactory.getLogger(this::class.java)
     }
 

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/push/TransferPush.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/push/TransferPush.kt
@@ -1,0 +1,9 @@
+package com.tencent.devops.common.websocket.dispatch.push
+
+abstract class TransferPush (
+    open val eventName: String?,
+    open val userId: String,
+    open var page: String?,
+    open var delayMills: Int? = 0,
+    open val transferData: Map<String, Any>
+)

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/push/TransferPush.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/dispatch/push/TransferPush.kt
@@ -1,6 +1,6 @@
 package com.tencent.devops.common.websocket.dispatch.push
 
-abstract class TransferPush (
+abstract class TransferPush(
     open val eventName: String?,
     open val userId: String,
     open var page: String?,

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/utils/RedisUtlis.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/utils/RedisUtlis.kt
@@ -25,9 +25,6 @@
  */
 
 package com.tencent.devops.common.websocket.utils
-
-import com.fasterxml.jackson.module.kotlin.readValue
-import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.redis.RedisOperation
 
 object RedisUtlis {

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/utils/RedisUtlis.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/utils/RedisUtlis.kt
@@ -29,7 +29,6 @@ package com.tencent.devops.common.websocket.utils
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.redis.RedisOperation
-import java.util.concurrent.TimeUnit
 
 object RedisUtlis {
 
@@ -55,7 +54,7 @@ object RedisUtlis {
                 redisOperation.set(USER_SESSION_REDIS_KEY + userId, newSessionList, null, true)
             }
         }
-        saveSessionTimeOutBySessionId(redisOperation, sessionId, userId)
+//        saveSessionTimeOutBySessionId(redisOperation, sessionId, userId)
     }
 
     // 获取userId对应的session集合。多个session以“,”隔开，用于做切割
@@ -204,45 +203,45 @@ object RedisUtlis {
         redisOperation.delete(PAGE_SESSION_REDIS_KEY + page)
     }
 
-    // 存储session对应的超时时间。所有session统一放到一个大的map内。默认超时时间是5天。此处可以做成可配置。
-    fun saveSessionTimeOutBySessionId(redisOperation: RedisOperation, sessionId: String, userId: String) {
-        // 默认超时时间，有清理线程定时清理已经超时的sessionId记录，防止在变更时调用loginOut失败。
-        val timeout = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(5)
-        val objectMapper = JsonUtil.getObjectMapper()
-        // 此处有一个内存隐患，get出来的map若很大，可能会导致频繁的gc
-        val cacheStr = redisOperation.get(USER_TIMEOUT_REDIS_KEY)
-        if (cacheStr != null) {
-            val cacheMap: MutableMap<String, String> = objectMapper.readValue(cacheStr)
-            cacheMap[sessionId] = "$timeout#$userId"
-            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(cacheMap))
-        } else {
-            val map = mutableMapOf<String, String>()
-            map[sessionId] = "$timeout#$userId"
-            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(map))
-        }
-    }
+//    // 存储session对应的超时时间。所有session统一放到一个大的map内。默认超时时间是5天。此处可以做成可配置。
+//    fun saveSessionTimeOutBySessionId(redisOperation: RedisOperation, sessionId: String, userId: String) {
+//        // 默认超时时间，有清理线程定时清理已经超时的sessionId记录，防止在变更时调用loginOut失败。
+//        val timeout = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(5)
+//        val objectMapper = JsonUtil.getObjectMapper()
+//        // 此处有一个内存隐患，get出来的map若很大，可能会导致频繁的gc
+//        val cacheStr = redisOperation.get(USER_TIMEOUT_REDIS_KEY)
+//        if (cacheStr != null) {
+//            val cacheMap: MutableMap<String, String> = objectMapper.readValue(cacheStr)
+//            cacheMap[sessionId] = "$timeout#$userId"
+//            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(cacheMap))
+//        } else {
+//            val map = mutableMapOf<String, String>()
+//            map[sessionId] = "$timeout#$userId"
+//            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(map))
+//        }
+//    }
 
-    // 保存session-timeout数据
-    fun saveSessionTimeOutAll(redisOperation: RedisOperation, sessionMap: String) {
-        redisOperation.getAndSet(USER_TIMEOUT_REDIS_KEY, sessionMap)
-    }
+//    // 保存session-timeout数据
+//    fun saveSessionTimeOutAll(redisOperation: RedisOperation, sessionMap: String) {
+//        redisOperation.getAndSet(USER_TIMEOUT_REDIS_KEY, sessionMap)
+//    }
 
-    fun getSessionTimeOutFromRedis(redisOperation: RedisOperation): String? {
-        return redisOperation.get(USER_TIMEOUT_REDIS_KEY)
-    }
+//    fun getSessionTimeOutFromRedis(redisOperation: RedisOperation): String? {
+//        return redisOperation.get(USER_TIMEOUT_REDIS_KEY)
+//    }
 
     // 清理超时map内的sessionId，用于loginOut，清理session
-    fun cleanSessionTimeOutBySession(redisOperation: RedisOperation, sessionId: String) {
-        val allSessionMap = getSessionTimeOutFromRedis(redisOperation)
-        if (allSessionMap != null) {
-            val objectMapper = JsonUtil.getObjectMapper()
-            var sessionMap: MutableMap<String, String> = objectMapper.readValue(allSessionMap)
-            if (sessionMap.containsKey(sessionId)) {
-                sessionMap.remove(sessionId)
-            }
-            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(sessionMap))
-        }
-    }
+//    fun cleanSessionTimeOutBySession(redisOperation: RedisOperation, sessionId: String) {
+//        val allSessionMap = getSessionTimeOutFromRedis(redisOperation)
+//        if (allSessionMap != null) {
+//            val objectMapper = JsonUtil.getObjectMapper()
+//            var sessionMap: MutableMap<String, String> = objectMapper.readValue(allSessionMap)
+//            if (sessionMap.containsKey(sessionId)) {
+//                sessionMap.remove(sessionId)
+//            }
+////            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(sessionMap))
+//        }
+//    }
 
     // 构建结束，清理所有再当前页面的websocket缓存。
     fun cleanBuildWebSocketCache(redisOperation: RedisOperation, page: String) {

--- a/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/utils/RedisUtlis.kt
+++ b/src/backend/ci/core/common/common-websocket/src/main/kotlin/com/tencent/devops/common/websocket/utils/RedisUtlis.kt
@@ -236,7 +236,7 @@ object RedisUtlis {
 //            if (sessionMap.containsKey(sessionId)) {
 //                sessionMap.remove(sessionId)
 //            }
-////            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(sessionMap))
+//            saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(sessionMap))
 //        }
 //    }
 

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/configuration/WebsocketConfiguration.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/configuration/WebsocketConfiguration.kt
@@ -126,11 +126,11 @@ class WebsocketConfiguration {
     ): ConnectChannelInterceptor {
         return ConnectChannelInterceptor(redisOperation)
     }
-    
+
     @Bean
     fun transferDispatch(
         rabbitTemplate: RabbitTemplate
-    ): TransferDispatch{
+    ): TransferDispatch {
         return TransferDispatch(rabbitTemplate)
     }
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/configuration/WebsocketConfiguration.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/configuration/WebsocketConfiguration.kt
@@ -28,6 +28,7 @@ package com.tencent.devops.websocket.configuration
 
 import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
 import com.tencent.devops.common.redis.RedisOperation
+import com.tencent.devops.common.websocket.dispatch.TransferDispatch
 import com.tencent.devops.common.websocket.dispatch.WebSocketDispatcher
 import com.tencent.devops.websocket.handler.ConnectChannelInterceptor
 import com.tencent.devops.websocket.listener.WebSocketListener
@@ -124,5 +125,12 @@ class WebsocketConfiguration {
         redisOperation: RedisOperation
     ): ConnectChannelInterceptor {
         return ConnectChannelInterceptor(redisOperation)
+    }
+    
+    @Bean
+    fun transferDispatch(
+        rabbitTemplate: RabbitTemplate
+    ): TransferDispatch{
+        return TransferDispatch(rabbitTemplate)
     }
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/controller/WsController.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/controller/WsController.kt
@@ -41,16 +41,16 @@ class WsController @Autowired constructor(
 
     @MessageMapping("/changePage")
     fun changePage(changePage: ChangePageDTO) {
-        websocketService.changePage(changePage.userId, changePage.sessionId, changePage.page, changePage.projectId)
+        websocketService.changePage(changePage.userId, changePage.sessionId, changePage.page, changePage.projectId, changePage.showProjectList)
     }
 
     @MessageMapping("/loginOut")
     fun loginOut(loginOutDTO: LoginOutDTO) {
-        websocketService.loginOut(loginOutDTO.userId, loginOutDTO.sessionId, loginOutDTO.page)
+        websocketService.loginOut(loginOutDTO.userId, loginOutDTO.sessionId, loginOutDTO.page, loginOutDTO.transferData)
     }
 
     @MessageMapping("/clearUserSession")
     fun clearUserSession(clearUserDTO: ClearUserDTO) {
-        websocketService.clearUserSession(clearUserDTO.userId, clearUserDTO.sessionId)
+        websocketService.clearUserSession(clearUserDTO.userId, clearUserDTO.sessionId, clearUserDTO.transferData)
     }
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -108,7 +108,7 @@ class ClearTimeoutCron(
                                 RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
                                 websocketService.removeCacheSession(sessionId)
                                 logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
-                            }else {
+                            } else {
                                 newSessionList.add(it)
                             }
                         }
@@ -116,12 +116,14 @@ class ClearTimeoutCron(
                         logger.warn("fail msg: ${e.message}")
                     }
                 }
-                redisOperation.set(
-                    WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket,
-                    objectMapper.writeValueAsString(newSessionList),
-                    null,
-                    true
-                )
+                if (newSessionList.isNotEmpty() && newSessionList.size > 0) {
+                    redisOperation.set(
+                        WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket,
+                        objectMapper.writeValueAsString(newSessionList),
+                        null,
+                        true
+                    )
+                }
             }
         }
     }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -93,22 +93,26 @@ class ClearTimeoutCron(
                 }
                 sessionList.forEach {
                     logger.info("clearTimeout redisStr[$it],redisKey[${WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket}")
-                    if (it != null && it.isNotEmpty()) {
-                        val timeout: Long = it.substringAfter("&").toLong()
-                        val userId = it.substringAfter("#").substringBefore("&")
-                        val sessionId = it.substringBefore("#")
-                        logger.info("clearTimeout str[$it] timeout[$timeout] userId[$userId] sessionId[$sessionId]")
-                        if (nowTime > timeout) {
-                            val sessionPage = RedisUtlis.getPageFromSessionPageBySession(redisOperation, sessionId)
-                            RedisUtlis.cleanSessionPageBySessionId(redisOperation, sessionId)
-                            if (sessionPage != null) {
-                                RedisUtlis.cleanPageSessionBySessionId(redisOperation, sessionId, sessionPage)
+                    try {
+                        if (it != null) {
+                            val timeout: Long = it.substringAfter("&").toLong()
+                            val userId = it.substringAfter("#").substringBefore("&")
+                            val sessionId = it.substringBefore("#")
+                            logger.info("clearTimeout str[$it] timeout[$timeout] userId[$userId] sessionId[$sessionId]")
+                            if (nowTime > timeout) {
+                                val sessionPage = RedisUtlis.getPageFromSessionPageBySession(redisOperation, sessionId)
+                                RedisUtlis.cleanSessionPageBySessionId(redisOperation, sessionId)
+                                if (sessionPage != null) {
+                                    RedisUtlis.cleanPageSessionBySessionId(redisOperation, sessionId, sessionPage)
+                                }
+                                RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
+                                websocketService.removeCacheSession(sessionId)
+                                logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
                             }
-                            RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
-                            websocketService.removeCacheSession(sessionId)
-                            logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
+                            newSessionList.add(it)
                         }
-                        newSessionList.add(it)
+                    } catch (e: Exception) {
+                        logger.warn("fail msg: ${e.message}")
                     }
                 }
                 redisOperation.set(

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.websocket.utils.RedisUtlis
+import com.tencent.devops.websocket.keys.WebsocketKeys
+import com.tencent.devops.websocket.servcie.WebsocketService
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -37,7 +39,8 @@ import org.springframework.stereotype.Component
 @Component
 class ClearTimeoutCron(
     private val redisOperation: RedisOperation,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val websocketService: WebsocketService
 ) {
 
     companion object {
@@ -47,29 +50,63 @@ class ClearTimeoutCron(
     /**
      * 每分钟一次，计算session是否已经超时，若超时，剔除该session关联的所有websocket redis信息。
      */
+//    @Scheduled(cron = "0 */1 * * * ?")
+//    fun clearTimeoutAllCache() {
+//        val nowTime = System.currentTimeMillis()
+//        val sessionTimeoutStr = RedisUtlis.getSessionTimeOutFromRedis(redisOperation)
+//        if (sessionTimeoutStr != null) {
+//            val sessionTimeoutMap: MutableMap<String, String> = objectMapper.readValue(sessionTimeoutStr)
+//            val newSessionMap = mutableMapOf<String, String>()
+//            sessionTimeoutMap.forEach { (sessionId, key) ->
+//                val timeout: Long = key.substringBefore("#").toLong()
+//                val userId = key.substringAfter("#")
+//                if (nowTime < timeout) {
+//                    newSessionMap[sessionId] = key
+//                } else {
+//                    val sessionPage = RedisUtlis.getPageFromSessionPageBySession(redisOperation, sessionId)
+//                    RedisUtlis.cleanSessionPageBySessionId(redisOperation, sessionId)
+//                    if (sessionPage != null) {
+//                        RedisUtlis.cleanPageSessionBySessionId(redisOperation, sessionId, sessionPage)
+//                    }
+//                    RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
+//                    websocketService.removeCacheSession(sessionId)
+//                    logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
+//                }
+//            }
+//            RedisUtlis.saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(newSessionMap))
+//        }
+//    }
+
+    /**
+     * 每分钟一次，计算session是否已经超时，若超时，剔除该session关联的所有websocket redis信息。
+     */
     @Scheduled(cron = "0 */1 * * * ?")
-    fun clearTimeoutAllCache() {
+    fun newClearTimeoutCache() {
         val nowTime = System.currentTimeMillis()
-        val sessionTimeoutStr = RedisUtlis.getSessionTimeOutFromRedis(redisOperation)
-        if (sessionTimeoutStr != null) {
-            val sessionTimeoutMap: MutableMap<String, String> = objectMapper.readValue(sessionTimeoutStr)
-            val newSessionMap = mutableMapOf<String, String>()
-            sessionTimeoutMap.forEach { (sessionId, key) ->
-                val timeout: Long = key.substringBefore("#").toLong()
-                val userId = key.substringAfter("#")
-                if (nowTime < timeout) {
-                    newSessionMap[sessionId] = key
-                } else {
-                    val sessionPage = RedisUtlis.getPageFromSessionPageBySession(redisOperation, sessionId)
-                    RedisUtlis.cleanSessionPageBySessionId(redisOperation, sessionId)
-                    if (sessionPage != null) {
-                        RedisUtlis.cleanPageSessionBySessionId(redisOperation, sessionId, sessionPage)
+        for (bucket in 0..WebsocketKeys.REDIS_MO){
+            val redisData = redisOperation.get(WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY+bucket)
+            if(redisData != null){
+                val newSessionList = mutableListOf<String>()
+                val sessionList = redisData.split(",")
+                sessionList.forEach {
+                    val timeout: Long = it.substringAfter("&").toLong()
+                    val userId = it.substringAfter("#").substringBefore("&")
+                    val sessionId = it.substringBefore("#")
+                    if (nowTime > timeout) {
+                        val sessionPage = RedisUtlis.getPageFromSessionPageBySession(redisOperation, sessionId)
+                        RedisUtlis.cleanSessionPageBySessionId(redisOperation, sessionId)
+                        if (sessionPage != null) {
+                            RedisUtlis.cleanPageSessionBySessionId(redisOperation, sessionId, sessionPage)
+                        }
+                        RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
+                        websocketService.removeCacheSession(sessionId)
+                        logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
                     }
-                    RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
-                    logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
+                    newSessionList.add(it)
                 }
+                redisOperation.set(WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY+bucket,objectMapper.writeValueAsString(newSessionList),null, true)
             }
-            RedisUtlis.saveSessionTimeOutAll(redisOperation, objectMapper.writeValueAsString(newSessionMap))
         }
+
     }
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -85,7 +85,7 @@ class ClearTimeoutCron(
         for (bucket in 0..WebsocketKeys.REDIS_MO) {
             val redisData = redisOperation.get(WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket)
             if (redisData != null) {
-                var newSessionList :String? = null
+                var newSessionList: String? = null
                 val sessionList = redisData.split(",")
                 if (sessionList == null || sessionList.isEmpty()) {
                     logger.info("this bucket is empty,redisKey[${WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket}]")
@@ -109,9 +109,9 @@ class ClearTimeoutCron(
                                 websocketService.removeCacheSession(sessionId)
                                 logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
                             } else {
-                                newSessionList = if(newSessionList == null){
+                                newSessionList = if (newSessionList == null) {
                                     it
-                                }else{
+                                } else {
                                     "$newSessionList,$it"
                                 }
                             }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -108,8 +108,9 @@ class ClearTimeoutCron(
                                 RedisUtlis.cleanUserSessionBySessionId(redisOperation, userId, sessionId)
                                 websocketService.removeCacheSession(sessionId)
                                 logger.info("[clearTimeOutSession] sessionId:$sessionId,loadPage:$sessionPage,userId:$userId")
+                            }else {
+                                newSessionList.add(it)
                             }
-                            newSessionList.add(it)
                         }
                     } catch (e: Exception) {
                         logger.warn("fail msg: ${e.message}")

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -91,6 +91,7 @@ class ClearTimeoutCron(
                     val timeout: Long = it.substringAfter("&").toLong()
                     val userId = it.substringAfter("#").substringBefore("&")
                     val sessionId = it.substringBefore("#")
+                    logger.info("clearTimeout str[$it] timeout[$timeout] userId[$userId] sessionId[$sessionId]")
                     if (nowTime > timeout) {
                         val sessionPage = RedisUtlis.getPageFromSessionPageBySession(redisOperation, sessionId)
                         RedisUtlis.cleanSessionPageBySessionId(redisOperation, sessionId)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -27,7 +27,6 @@
 package com.tencent.devops.websocket.cron
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.websocket.utils.RedisUtlis
 import com.tencent.devops.websocket.keys.WebsocketKeys

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/cron/ClearTimeoutCron.kt
@@ -87,7 +87,11 @@ class ClearTimeoutCron(
             if(redisData != null){
                 val newSessionList = mutableListOf<String>()
                 val sessionList = redisData.split(",")
+                if(sessionList == null || sessionList.isEmpty()){
+                    continue
+                }
                 sessionList.forEach {
+                    logger.info("clearTimeout redisStr[$it]")
                     val timeout: Long = it.substringAfter("&").toLong()
                     val userId = it.substringAfter("#").substringBefore("&")
                     val sessionId = it.substringBefore("#")

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ChangePageTransferEvent.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ChangePageTransferEvent.kt
@@ -6,9 +6,9 @@ import com.tencent.devops.common.websocket.dispatch.push.TransferPush
 
 @Event(exchange = MQ.EXCHANGE_WEBSOCKET_TRANSFER_FANOUT, routeKey = MQ.ROUTE_WEBSOCKET_TRANSFER_EVENT)
 class ChangePageTransferEvent(
-    override val eventName: String ?= "changePageEvent",
+    override val eventName: String? = "changePageEvent",
     override val userId: String,
     override var page: String?,
-    override var delayMills: Int?=0,
+    override var delayMills: Int? = 0,
     override val transferData: Map<String, Any>
-): TransferPush(eventName, userId, page,delayMills, transferData)
+) : TransferPush(eventName, userId, page, delayMills, transferData)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ChangePageTransferEvent.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ChangePageTransferEvent.kt
@@ -1,0 +1,14 @@
+package com.tencent.devops.websocket.event
+
+import com.tencent.devops.common.event.annotation.Event
+import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
+import com.tencent.devops.common.websocket.dispatch.push.TransferPush
+
+@Event(exchange = MQ.EXCHANGE_WEBSOCKET_TRANSFER_FANOUT, routeKey = MQ.ROUTE_WEBSOCKET_TRANSFER_EVENT)
+class ChangePageTransferEvent(
+    override val eventName: String ?= "changePageEvent",
+    override val userId: String,
+    override var page: String?,
+    override var delayMills: Int?=0,
+    override val transferData: Map<String, Any>
+): TransferPush(eventName, userId, page,delayMills, transferData)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ClearUserSessionTransferEvent.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ClearUserSessionTransferEvent.kt
@@ -1,0 +1,14 @@
+package com.tencent.devops.websocket.event
+
+import com.tencent.devops.common.event.annotation.Event
+import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
+import com.tencent.devops.common.websocket.dispatch.push.TransferPush
+
+@Event(exchange = MQ.EXCHANGE_WEBSOCKET_TRANSFER_FANOUT, routeKey = MQ.ROUTE_WEBSOCKET_TRANSFER_EVENT)
+class ClearUserSessionTransferEvent (
+    override val eventName: String ?= "clearUserSessionEvent",
+    override val userId: String,
+    override var page: String?,
+    override var delayMills: Int?=0,
+    override val transferData: Map<String, Any>
+): TransferPush(eventName, userId, page, delayMills, transferData)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ClearUserSessionTransferEvent.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/ClearUserSessionTransferEvent.kt
@@ -5,10 +5,10 @@ import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
 import com.tencent.devops.common.websocket.dispatch.push.TransferPush
 
 @Event(exchange = MQ.EXCHANGE_WEBSOCKET_TRANSFER_FANOUT, routeKey = MQ.ROUTE_WEBSOCKET_TRANSFER_EVENT)
-class ClearUserSessionTransferEvent (
-    override val eventName: String ?= "clearUserSessionEvent",
+class ClearUserSessionTransferEvent(
+    override val eventName: String? = "clearUserSessionEvent",
     override val userId: String,
     override var page: String?,
-    override var delayMills: Int?=0,
+    override var delayMills: Int? = 0,
     override val transferData: Map<String, Any>
-): TransferPush(eventName, userId, page, delayMills, transferData)
+) : TransferPush(eventName, userId, page, delayMills, transferData)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/LoginOutTransferEvent.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/LoginOutTransferEvent.kt
@@ -6,9 +6,9 @@ import com.tencent.devops.common.websocket.dispatch.push.TransferPush
 
 @Event(exchange = MQ.EXCHANGE_WEBSOCKET_TRANSFER_FANOUT, routeKey = MQ.ROUTE_WEBSOCKET_TRANSFER_EVENT)
 class LoginOutTransferEvent(
-    override val eventName: String ?= "loginOutEvent",
+    override val eventName: String? = "loginOutEvent",
     override val userId: String,
     override var page: String?,
-    override var delayMills: Int?=0,
+    override var delayMills: Int? = 0,
     override val transferData: Map<String, Any>
 ) : TransferPush(eventName, userId, page, delayMills, transferData)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/LoginOutTransferEvent.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/event/LoginOutTransferEvent.kt
@@ -1,0 +1,14 @@
+package com.tencent.devops.websocket.event
+
+import com.tencent.devops.common.event.annotation.Event
+import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
+import com.tencent.devops.common.websocket.dispatch.push.TransferPush
+
+@Event(exchange = MQ.EXCHANGE_WEBSOCKET_TRANSFER_FANOUT, routeKey = MQ.ROUTE_WEBSOCKET_TRANSFER_EVENT)
+class LoginOutTransferEvent(
+    override val eventName: String ?= "loginOutEvent",
+    override val userId: String,
+    override var page: String?,
+    override var delayMills: Int?=0,
+    override val transferData: Map<String, Any>
+) : TransferPush(eventName, userId, page, delayMills, transferData)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
@@ -1,0 +1,10 @@
+package com.tencent.devops.websocket.keys
+
+object WebsocketKeys {
+    // session超时 redis桶数量
+    const val REDIS_MO:Long = 1000
+    // 记录登录态超时hash redis桶， BK:webSocket:hash:sessionId:timeOut:key:1-1000,所有的登录态被打散到1000个桶内
+    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:webSocket:hash:sessionId:timeOut:key:"
+    // 用户项目redis key
+    const val PROJECT_USER_REDIS_KEY = "BK:websocket:project:user:key:"
+}

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
@@ -4,7 +4,7 @@ object WebsocketKeys {
     // session超时 redis桶数量
     const val REDIS_MO:Long = 1000
     // 记录登录态超时hash redis桶， BK:webSocket:hash:sessionId:timeOut:key:1-1000,所有的登录态被打散到1000个桶内
-    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:ws:sessionId:timeOut:hashBucket:key:"
+    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:wsSessionId:timeOut:hashBucket:key:"
     // 用户项目redis key
     const val PROJECT_USER_REDIS_KEY = "BK:websocket:project:user:key:"
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
@@ -4,7 +4,7 @@ object WebsocketKeys {
     // session超时 redis桶数量
     const val REDIS_MO:Long = 1000
     // 记录登录态超时hash redis桶， BK:webSocket:hash:sessionId:timeOut:key:1-1000,所有的登录态被打散到1000个桶内
-    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:webSocket:sessionId:timeOut:hashBucket:key:"
+    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:ws:sessionId:timeOut:hashBucket:key:"
     // 用户项目redis key
     const val PROJECT_USER_REDIS_KEY = "BK:websocket:project:user:key:"
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
@@ -2,7 +2,7 @@ package com.tencent.devops.websocket.keys
 
 object WebsocketKeys {
     // session超时 redis桶数量
-    const val REDIS_MO:Long = 1000
+    const val REDIS_MO: Long = 1000
     // 记录登录态超时hash redis桶， BK:webSocket:hash:sessionId:timeOut:key:1-1000,所有的登录态被打散到1000个桶内
     const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:wsSessionId:timeOut:hashBucket:key:"
     // 用户项目redis key

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
@@ -4,7 +4,7 @@ object WebsocketKeys {
     // session超时 redis桶数量
     const val REDIS_MO:Long = 1000
     // 记录登录态超时hash redis桶， BK:webSocket:hash:sessionId:timeOut:key:1-1000,所有的登录态被打散到1000个桶内
-    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:webSocket:hash:sessionId:timeOut:key:"
+    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:webSocket:hashBucket:sessionId:timeOut:key:"
     // 用户项目redis key
     const val PROJECT_USER_REDIS_KEY = "BK:websocket:project:user:key:"
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/keys/WebsocketKeys.kt
@@ -4,7 +4,7 @@ object WebsocketKeys {
     // session超时 redis桶数量
     const val REDIS_MO:Long = 1000
     // 记录登录态超时hash redis桶， BK:webSocket:hash:sessionId:timeOut:key:1-1000,所有的登录态被打散到1000个桶内
-    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:webSocket:hashBucket:sessionId:timeOut:key:"
+    const val HASH_USER_TIMEOUT_REDIS_KEY = "BK:webSocket:sessionId:timeOut:hashBucket:key:"
     // 用户项目redis key
     const val PROJECT_USER_REDIS_KEY = "BK:websocket:project:user:key:"
 }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/listener/WebSocketListener.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/listener/WebSocketListener.kt
@@ -59,7 +59,7 @@ class WebSocketListener @Autowired constructor(
                             "/topic/bk/notify/$session",
                             objectMapper.writeValueAsString(event.notifyPost)
                         )
-                        if(System.currentTimeMillis() - pushStartTime > 500){
+                        if (System.currentTimeMillis() - pushStartTime > 500) {
                             logger.warn("WebSocketListener push msg consuming 500ms, page[$event.page], session[$session]")
                         }
                     }
@@ -67,7 +67,7 @@ class WebSocketListener @Autowired constructor(
             } else {
                 logger.info("webSocketListener sessionList is empty. page:${event.page} user:${event.userId} ")
             }
-            if(System.currentTimeMillis() - startTime > 1000){
+            if (System.currentTimeMillis() - startTime > 1000) {
                 logger.warn("WebSocketListener push all message consuming 1s, page[$event.page], session[${event.sessionList}]")
             }
         } catch (ex: Exception) {

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ChangePageDTO.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ChangePageDTO.kt
@@ -32,5 +32,5 @@ data class ChangePageDTO(
     val page: String,
     val projectId: String,
     val showProjectList: Boolean,
-    val transferData: Map<String,Any>?
+    val transferData: Map<String, Any>?
 )

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ChangePageDTO.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ChangePageDTO.kt
@@ -30,5 +30,7 @@ data class ChangePageDTO(
     val userId: String,
     val sessionId: String,
     val page: String,
-    val projectId: String
+    val projectId: String,
+    val showProjectList: Boolean,
+    val transferData: Map<String,Any>?
 )

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ClearUserDTO.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ClearUserDTO.kt
@@ -28,5 +28,6 @@ package com.tencent.devops.websocket.pojo
 
 data class ClearUserDTO(
     val userId: String,
-    val sessionId: String
+    val sessionId: String,
+    val transferData: Map<String,Any>?
 )

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ClearUserDTO.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/ClearUserDTO.kt
@@ -29,5 +29,5 @@ package com.tencent.devops.websocket.pojo
 data class ClearUserDTO(
     val userId: String,
     val sessionId: String,
-    val transferData: Map<String,Any>?
+    val transferData: Map<String, Any>?
 )

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/LoginOutDTO.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/LoginOutDTO.kt
@@ -29,5 +29,6 @@ package com.tencent.devops.websocket.pojo
 data class LoginOutDTO(
     val userId: String,
     val sessionId: String,
-    val page: String? = null
+    val page: String? = null,
+    val transferData: Map<String,Any>?
 )

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/LoginOutDTO.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/pojo/LoginOutDTO.kt
@@ -30,5 +30,5 @@ data class LoginOutDTO(
     val userId: String,
     val sessionId: String,
     val page: String? = null,
-    val transferData: Map<String,Any>?
+    val transferData: Map<String, Any>?
 )

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/ProjectProxyServiceImpl.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/ProjectProxyServiceImpl.kt
@@ -43,10 +43,10 @@ class ProjectProxyServiceImpl @Autowired constructor(
 ) : ProjectProxyService {
     override fun checkProject(projectId: String, userId: String): Boolean {
         try {
-            val redisData = redisOperation.get(WebsocketKeys.PROJECT_USER_REDIS_KEY+userId)
-            if(redisData != null){
+            val redisData = redisOperation.get(WebsocketKeys.PROJECT_USER_REDIS_KEY + userId)
+            if (redisData != null) {
                 val redisProjectList = redisData.split(",")
-                if(redisProjectList.contains(projectId)){
+                if (redisProjectList.contains(projectId)) {
                     return true
                 }
             }
@@ -56,7 +56,10 @@ class ProjectProxyServiceImpl @Autowired constructor(
             projectList?.map {
                 privilegeProjectCodeList.add(it.projectCode)
             }
-            redisOperation.set(WebsocketKeys.PROJECT_USER_REDIS_KEY+userId, objectMapper.writeValueAsString(privilegeProjectCodeList))
+            redisOperation.set(
+                WebsocketKeys.PROJECT_USER_REDIS_KEY + userId,
+                objectMapper.writeValueAsString(privilegeProjectCodeList)
+            )
 
             return if (privilegeProjectCodeList.contains(projectId)) {
                 true

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
@@ -189,7 +189,7 @@ class WebsocketService @Autowired constructor(
 
     fun addCacheSession(sessionId: String) {
         if (cacheSessionList.contains(sessionId)) {
-            logger.warn("this session already in cacheSession")
+            logger.warn("this session[$sessionId] already in cacheSession")
             return
         }
         cacheSessionList.add(sessionId)
@@ -201,6 +201,7 @@ class WebsocketService @Autowired constructor(
 
     fun isCacheSession(sessionId: String): Boolean {
         if (cacheSessionList.contains(sessionId)) {
+            logger.info("sessionId[$sessionId] is in this host")
             return true
         }
         return false

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
@@ -212,6 +212,7 @@ class WebsocketService @Autowired constructor(
         val redisData = "$sessionId#$userId&$timeout"
         //hash后对1000取模，将数据打散到1000个桶内
         val redisHashKey = WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY+redisData.hashCode().rem(WebsocketKeys.REDIS_MO)
+        logger.info("redis hash sessionId[$sessionId] userId[$userId] redisHashKey[$redisHashKey]")
         var timeoutData = redisOperation.get(redisHashKey)
         if(timeoutData != null) {
             redisOperation.set(redisHashKey, redisData, null, true)

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
@@ -210,7 +210,7 @@ class WebsocketService @Autowired constructor(
     fun createTimeoutSession(sessionId: String, userId: String) {
         val timeout = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(sessionTimeOut!!)
         val redisData = "$sessionId#$userId&$timeout"
-        //hash后对1000取模，将数据打散到1000个桶内
+        // hash后对1000取模，将数据打散到1000个桶内
         var bucket = redisData.hashCode().rem(WebsocketKeys.REDIS_MO)
         if (bucket < 0) bucket *= -1
         val redisHashKey = WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
@@ -68,7 +68,7 @@ class WebsocketService @Autowired constructor(
         newPage: String,
         projectId: String,
         needCheckProject: Boolean,
-        transferData: Map<String, Any>?= emptyMap()
+        transferData: Map<String, Any>? = emptyMap()
     ) {
         if (needCheckProject && projectId.isNotEmpty()) {
             if (!projectProxyService.checkProject(projectId, userId)) {
@@ -109,7 +109,7 @@ class WebsocketService @Autowired constructor(
                 )}]"
             )
             logger.info("sessionPage[session:$sessionId,page:$normalPage]")
-            if(needTransfer && transferData!!.isNotEmpty()){
+            if (needTransfer && transferData!!.isNotEmpty()) {
                 transferDispatch.dispatch(
                     ChangePageTransferEvent(
                         userId = userId,
@@ -127,7 +127,7 @@ class WebsocketService @Autowired constructor(
         userId: String,
         sessionId: String,
         oldPage: String?,
-        transferData: Map<String, Any>?= emptyMap()
+        transferData: Map<String, Any>? = emptyMap()
     ) {
         if (!checkParams(userId, sessionId)) {
             logger.warn("loginOut checkFail: [userId:$userId,sessionId:$sessionId")
@@ -149,7 +149,7 @@ class WebsocketService @Autowired constructor(
             } else if (page != null) {
                 RedisUtlis.cleanPageSessionBySessionId(redisOperation, page, sessionId)
             }
-            if(needTransfer && transferData!!.isNotEmpty()){
+            if (needTransfer && transferData!!.isNotEmpty()) {
                 transferDispatch.dispatch(
                     LoginOutTransferEvent(
                         userId = userId,
@@ -173,7 +173,7 @@ class WebsocketService @Autowired constructor(
 //            RedisUtlis.cleanSessionTimeOutBySession(redisOperation, sessionId)
             removeCacheSession(sessionId)
             logger.info("after clearUserSession:${RedisUtlis.getSessionIdByUserId(redisOperation, userId)}")
-            if(needTransfer && transferData!!.isNotEmpty()){
+            if (needTransfer && transferData!!.isNotEmpty()) {
                 transferDispatch.dispatch(
                     ClearUserSessionTransferEvent(
                         userId = userId,
@@ -207,18 +207,18 @@ class WebsocketService @Autowired constructor(
         return false
     }
 
-    fun createTimeoutSession(sessionId: String, userId: String){
+    fun createTimeoutSession(sessionId: String, userId: String) {
         val timeout = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(sessionTimeOut!!)
         val redisData = "$sessionId#$userId&$timeout"
         //hash后对1000取模，将数据打散到1000个桶内
         var bucket = redisData.hashCode().rem(WebsocketKeys.REDIS_MO)
-        if(bucket < 0) bucket *= -1
-        val redisHashKey = WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY+bucket
+        if (bucket < 0) bucket *= -1
+        val redisHashKey = WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY + bucket
         logger.info("redis hash sessionId[$sessionId] userId[$userId] redisHashKey[$redisHashKey]")
         var timeoutData = redisOperation.get(redisHashKey)
-        if(timeoutData != null) {
+        if (timeoutData != null) {
             redisOperation.set(redisHashKey, timeoutData, null, true)
-        }else{
+        } else {
             timeoutData = "$timeoutData,$redisData"
             redisOperation.set(redisHashKey, timeoutData, null, true)
         }

--- a/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
+++ b/src/backend/ci/core/websocket/biz-websocket/src/main/kotlin/com/tencent/devops/websocket/servcie/WebsocketService.kt
@@ -29,15 +29,23 @@ package com.tencent.devops.websocket.servcie
 import com.tencent.devops.common.client.Client
 import com.tencent.devops.common.redis.RedisLock
 import com.tencent.devops.common.redis.RedisOperation
+import com.tencent.devops.common.websocket.dispatch.TransferDispatch
 import com.tencent.devops.common.websocket.utils.RedisUtlis
+import com.tencent.devops.websocket.event.ChangePageTransferEvent
+import com.tencent.devops.websocket.event.ClearUserSessionTransferEvent
+import com.tencent.devops.websocket.event.LoginOutTransferEvent
+import com.tencent.devops.websocket.keys.WebsocketKeys
 import com.tencent.devops.websocket.utils.PageUtils
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 
 @Service
 class WebsocketService @Autowired constructor(
     private val redisOperation: RedisOperation,
+    private val transferDispatch: TransferDispatch,
     private val client: Client,
     private val projectProxyService: ProjectProxyService
 ) {
@@ -45,10 +53,27 @@ class WebsocketService @Autowired constructor(
         private val logger = LoggerFactory.getLogger(this::class.java)
     }
 
+    @Value("\${transferData:false}")
+    private val needTransfer: Boolean = false
+
+    @Value("\${session.timeout:5}")
+    private val sessionTimeOut: Long? = null
+
+    private val cacheSessionList = mutableListOf<String>()
+
     // 用户切换页面，需调整sessionId-page,page-sessionIdList两个map
-    fun changePage(userId: String, sessionId: String, newPage: String, projectId: String) {
-        if (!projectProxyService.checkProject(projectId, userId)) {
-            return
+    fun changePage(
+        userId: String,
+        sessionId: String,
+        newPage: String,
+        projectId: String,
+        needCheckProject: Boolean,
+        transferData: Map<String, Any>?= emptyMap()
+    ) {
+        if (needCheckProject && projectId.isNotEmpty()) {
+            if (!projectProxyService.checkProject(projectId, userId)) {
+                return
+            }
         }
         val redisLock = lockUser(sessionId)
         try {
@@ -84,12 +109,26 @@ class WebsocketService @Autowired constructor(
                 )}]"
             )
             logger.info("sessionPage[session:$sessionId,page:$normalPage]")
+            if(needTransfer && transferData!!.isNotEmpty()){
+                transferDispatch.dispatch(
+                    ChangePageTransferEvent(
+                        userId = userId,
+                        page = newPage,
+                        transferData = transferData
+                    )
+                )
+            }
         } finally {
             redisLock.unlock()
         }
     }
 
-    fun loginOut(userId: String, sessionId: String, oldPage: String?) {
+    fun loginOut(
+        userId: String,
+        sessionId: String,
+        oldPage: String?,
+        transferData: Map<String, Any>?= emptyMap()
+    ) {
         if (!checkParams(userId, sessionId)) {
             logger.warn("loginOut checkFail: [userId:$userId,sessionId:$sessionId")
             return
@@ -110,22 +149,74 @@ class WebsocketService @Autowired constructor(
             } else if (page != null) {
                 RedisUtlis.cleanPageSessionBySessionId(redisOperation, page, sessionId)
             }
+            if(needTransfer && transferData!!.isNotEmpty()){
+                transferDispatch.dispatch(
+                    LoginOutTransferEvent(
+                        userId = userId,
+                        page = oldPage,
+                        transferData = transferData
+                    )
+                )
+            }
         } finally {
             redisLock.unlock()
         }
     }
 
-    fun clearUserSession(userId: String, sessionId: String) {
+    fun clearUserSession(userId: String, sessionId: String, transferData: Map<String, Any>?) {
         val redisLock = lockUser(sessionId)
         try {
             redisLock.lock()
             logger.info("clearUserSession:user:$userId,sessionId:$sessionId")
             logger.info("before clearUserSession:${RedisUtlis.getSessionIdByUserId(redisOperation, userId)}")
             RedisUtlis.deleteSigelSessionByUser(redisOperation, userId, sessionId)
-            RedisUtlis.cleanSessionTimeOutBySession(redisOperation, sessionId)
+//            RedisUtlis.cleanSessionTimeOutBySession(redisOperation, sessionId)
+            removeCacheSession(sessionId)
             logger.info("after clearUserSession:${RedisUtlis.getSessionIdByUserId(redisOperation, userId)}")
+            if(needTransfer && transferData!!.isNotEmpty()){
+                transferDispatch.dispatch(
+                    ClearUserSessionTransferEvent(
+                        userId = userId,
+                        page = "",
+                        transferData = transferData
+                    )
+                )
+            }
         } finally {
             redisLock.unlock()
+        }
+    }
+
+    fun addCacheSession(sessionId: String) {
+        if (cacheSessionList.contains(sessionId)) {
+            logger.warn("this session already in cacheSession")
+            return
+        }
+        cacheSessionList.add(sessionId)
+    }
+
+    fun removeCacheSession(sessionId: String) {
+        cacheSessionList.remove(sessionId)
+    }
+
+    fun isCacheSession(sessionId: String): Boolean {
+        if (cacheSessionList.contains(sessionId)) {
+            return true
+        }
+        return false
+    }
+
+    fun createTimeoutSession(sessionId: String, userId: String){
+        val timeout = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(sessionTimeOut!!)
+        val redisData = "$sessionId#$userId&$timeout"
+        //hash后对1000取模，将数据打散到1000个桶内
+        val redisHashKey = WebsocketKeys.HASH_USER_TIMEOUT_REDIS_KEY+redisData.hashCode().rem(WebsocketKeys.REDIS_MO)
+        var timeoutData = redisOperation.get(redisHashKey)
+        if(timeoutData != null) {
+            redisOperation.set(redisHashKey, redisData, null, true)
+        }else{
+            timeoutData = "$timeoutData,$redisData"
+            redisOperation.set(redisHashKey, timeoutData, null, true)
         }
     }
 


### PR DESCRIPTION
1. 实例内部维护session，非本实例session不push。
2. 添加消息下发mq功能，前端只需与websocket交互，由websocket广播其他消息。
3. 修改timeout数据接口。由原来的大list改为1000个桶，超时计算遍历此1000个桶。
4. 校验项目添加redis缓存，加快changePage速度，解决推送偶现有延迟问题。