### PR TITLE
bugfix: process迁移部分接口url中的变量名和接口定义的接收变量名不一致 issue #660

### DIFF
--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/api/service/ServiceBuildResource.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/api/service/ServiceBuildResource.kt
@@ -389,7 +389,7 @@ interface ServiceBuildResource {
     @ApiOperation("根据流水线id获取最新执行信息")
     @POST
     // @Path("/projects/{projectId}/getPipelineLatestBuild")
-    @Path("/{projectCode}/getPipelineLatestBuild")
+    @Path("/{projectId}/getPipelineLatestBuild")
     fun getPipelineLatestBuildByIds(
         @ApiParam("项目id", required = true)
         @PathParam("projectId")
@@ -401,7 +401,7 @@ interface ServiceBuildResource {
     @ApiOperation("第三方构建机Agent构建结束")
     @POST
     // @Path("/projects/{projectId}/pipelines/{pipelineId}/builds/{buildId}/seqs/{vmSeqId}/workerBuildFinish")
-    @Path("/{projectCode}/{pipelineId}/{buildId}/{vmSeqId}/workerBuildFinish")
+    @Path("/{projectId}/{pipelineId}/{buildId}/{vmSeqId}/workerBuildFinish")
     fun workerBuildFinish(
         @ApiParam("项目id", required = true)
         @PathParam("projectId")


### PR DESCRIPTION
fix #660 
process迁移部分接口url中的变量名和接口定义的接收变量名不一致