### PR TITLE
refactor: BuildType枚举类外部Docker公共构建机的名称规范 issue #712

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/type/BuildType.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/type/BuildType.kt
@@ -37,7 +37,7 @@ enum class BuildType(
 ) {
     ESXi("蓝盾公共构建资源", listOf(OS.MACOS), true, false, false),
     MACOS("蓝盾公共构建资源(NEW)", listOf(OS.MACOS), true, false, false),
-    DOCKER("公共：Docker on Devnet 物理机", listOf(OS.LINUX), true, true, true),
+    DOCKER("Docker公共构建机", listOf(OS.LINUX), true, true, true),
     IDC("公共：Docker on IDC CVM", listOf(OS.LINUX), true, false, false),
     PUBLIC_DEVCLOUD("公共：Docker on DevCloud", listOf(OS.LINUX), true, false, false),
     TSTACK("Windows构建", listOf(OS.WINDOWS), false, false, false), // tstack is deleted


### PR DESCRIPTION
close #712 