### PR TITLE
Feature: 流水线企业微信群通知应支持 Markdown 格式 Pipeline notification should support markdown when push to Wechat work group issue #416

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/dao/PipelineSettingDao.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/dao/PipelineSettingDao.kt
@@ -166,7 +166,7 @@ class PipelineSettingDao {
                 .set(FAIL_WECHAT_GROUP_MARKDOWN_FLAG, setting.failSubscription.wechatGroupMarkdownFlag)
                 .set(SUCCESS_WECHAT_GROUP_FLAG, setting.successSubscription.wechatGroupFlag)
                 .set(SUCCESS_WECHAT_GROUP, setting.successSubscription.wechatGroup)
-                .set(FAIL_WECHAT_GROUP_MARKDOWN_FLAG, setting.successSubscription.wechatGroupMarkdownFlag)
+                .set(SUCCESS_WECHAT_GROUP_MARKDOWN_FLAG, setting.successSubscription.wechatGroupMarkdownFlag)
                 .set(SUCCESS_DETAIL_FLAG, setting.successSubscription.detailFlag)
                 .set(FAIL_DETAIL_FLAG, setting.failSubscription.detailFlag)
                 .set(SUCCESS_CONTENT, setting.successSubscription.content)


### PR DESCRIPTION
Feature request: 流水线企业微信群通知应支持 Markdown 格式 Pipeline notification should support markdown when push to Wechat work group issue #416
修复数据库字段写入错误的bug