### PR TITLE
bugfix: docker项目专用构建机 #781

### DIFF
--- a/src/backend/ci/core/dispatch/biz-dispatch-docker/src/main/kotlin/com/tencent/devops/dispatch/dao/PipelineDockerHostDao.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch-docker/src/main/kotlin/com/tencent/devops/dispatch/dao/PipelineDockerHostDao.kt
@@ -44,28 +44,47 @@ class PipelineDockerHostDao {
     ): Int {
         with(TDispatchPipelineDockerHost.T_DISPATCH_PIPELINE_DOCKER_HOST) {
             val now = LocalDateTime.now()
-            return dslContext.insertInto(this,
-                    PROJECT_CODE,
-                    HOST_IP,
-                    REMARK,
-                    CREATED_TIME,
-                    UPDATED_TIME)
-                    .values(
-                            projectId,
-                            hostIp,
-                            remark ?: "",
-                            now,
-                            now
-                    ).execute()
+            return dslContext.insertInto(
+                this,
+                PROJECT_CODE,
+                HOST_IP,
+                REMARK,
+                CREATED_TIME,
+                UPDATED_TIME
+            )
+                .values(
+                    projectId,
+                    hostIp,
+                    remark ?: "",
+                    now,
+                    now
+                ).execute()
         }
     }
 
-    fun getHost(dslContext: DSLContext, projectId: String, type: DockerHostType = DockerHostType.BUILD): TDispatchPipelineDockerHostRecord? {
+    fun getHost(
+        dslContext: DSLContext,
+        projectId: String,
+        type: DockerHostType = DockerHostType.BUILD
+    ): TDispatchPipelineDockerHostRecord? {
         with(TDispatchPipelineDockerHost.T_DISPATCH_PIPELINE_DOCKER_HOST) {
             return dslContext.selectFrom(this)
                 .where(PROJECT_CODE.eq(projectId))
                 .and(TYPE.eq(type.ordinal))
-                .fetchOne()
+                .fetchAny()
+        }
+    }
+
+    fun getHostIps(
+        dslContext: DSLContext,
+        projectId: String,
+        type: DockerHostType = DockerHostType.BUILD
+    ): List<String> {
+        with(TDispatchPipelineDockerHost.T_DISPATCH_PIPELINE_DOCKER_HOST) {
+            return dslContext.select(HOST_IP)
+                .where(PROJECT_CODE.eq(projectId))
+                .and(TYPE.eq(type.ordinal))
+                .fetch(HOST_IP, String::class.java)
         }
     }
 }

--- a/src/backend/ci/core/dispatch/biz-dispatch-docker/src/main/kotlin/com/tencent/devops/dispatch/dao/PipelineDockerTaskDao.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch-docker/src/main/kotlin/com/tencent/devops/dispatch/dao/PipelineDockerTaskDao.kt
@@ -344,6 +344,18 @@ class PipelineDockerTaskDao {
         }
     }
 
+    fun clearHostTagForUnclaimedHostTask(dslContext: DSLContext, buildId: String, vmSeqId: Int): Boolean {
+        with(TDispatchPipelineDockerTask.T_DISPATCH_PIPELINE_DOCKER_TASK) {
+            return dslContext.update(this)
+                .set(HOST_TAG, "")
+                .where(BUILD_ID.eq(buildId))
+                .and(VM_SEQ_ID.eq(vmSeqId))
+                .and(STATUS.eq(PipelineTaskStatus.QUEUE.status))
+                .and(HOST_TAG.isNotNull).and(HOST_TAG.notEqual(""))
+                .execute() > 0
+        }
+    }
+
     fun clearHostTagForUnclaimedHostTask(dslContext: DSLContext): Boolean {
         with(TDispatchPipelineDockerTask.T_DISPATCH_PIPELINE_DOCKER_TASK) {
             return dslContext.update(this)


### PR DESCRIPTION
 专用构建机上存在一些特殊的依赖环境或配置，所以即使飘移到公共集群也会无法正常构建，所以专用构建机不允许柔性处理
 如果专用构建机故障，则无法正常工作，需要解决专用构建机故障问题