### PR TITLE
bugfix: issue #927流水线插件全部执行完成后，构建无法自动终止

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/init/PipelineExtendConfiguration.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/init/PipelineExtendConfiguration.kt
@@ -60,6 +60,16 @@ class PipelineExtendConfiguration {
     }
 
     /**
+     * 插件结束后续广播exchange
+     */
+    @Bean
+    fun pipelineBuildElementFinishFanoutExchange(): FanoutExchange {
+        val fanoutExchange = FanoutExchange(MQ.EXCHANGE_PIPELINE_BUILD_ELEMENT_FINISH_FANOUT, true, false)
+        fanoutExchange.isDelayed = true
+        return fanoutExchange
+    }
+
+    /**
      * 构建构建回调广播交换机
      */
     @Bean


### PR DESCRIPTION
bugfix: issue #927流水线插件全部执行完成后，构建无法自动终止