### PR TITLE
bug:流水线插件全部执行完成后，构建无法自动终止 #927

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/TaskAtomService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/TaskAtomService.kt
@@ -32,7 +32,6 @@ import com.tencent.devops.common.api.util.timestampmilli
 import com.tencent.devops.common.event.dispatcher.pipeline.PipelineEventDispatcher
 import com.tencent.devops.common.event.enums.ActionType
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildStatusBroadCastEvent
-import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildTaskFinishBroadCastEvent
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.utils.SkipElementUtils
 import com.tencent.devops.common.service.utils.CommonUtils
@@ -179,7 +178,8 @@ class TaskAtomService @Autowired(required = false) constructor(
                 executeCount = task.executeCount,
                 errorType = errorType?.name,
                 errorCode = errorCode,
-                errorMsg = errorMsg
+                errorMsg = errorMsg,
+                userId = task.starter
             )
             if (BuildStatus.isFailure(status)) {
                 jmxElements.fail(elementType)
@@ -188,17 +188,6 @@ class TaskAtomService @Autowired(required = false) constructor(
             logger.error("Fail to post the task($task): ${ignored.message}")
         }
         pipelineEventDispatcher.dispatch(
-            PipelineBuildTaskFinishBroadCastEvent(
-                source = "build-element-${task.taskId}",
-                projectId = task.projectId,
-                pipelineId = task.pipelineId,
-                userId = "",
-                buildId = task.buildId,
-                taskId = task.taskId,
-                errorType = if (task.errorType == null) null else task.errorType!!.name,
-                errorCode = task.errorCode,
-                errorMsg = task.errorMsg
-            ),
             PipelineBuildStatusBroadCastEvent(
                 source = "task-end-${task.taskId}",
                 projectId = task.projectId,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/listener/run/finish/PipelineBuildCancelListener.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/listener/run/finish/PipelineBuildCancelListener.kt
@@ -41,6 +41,7 @@ import com.tencent.devops.process.engine.pojo.event.PipelineBuildCancelEvent
 import com.tencent.devops.process.engine.pojo.event.PipelineBuildFinishEvent
 import com.tencent.devops.process.engine.service.PipelineBuildDetailService
 import com.tencent.devops.process.engine.service.PipelineRuntimeService
+import com.tencent.devops.process.engine.service.measure.MeasureService
 import com.tencent.devops.process.pojo.mq.PipelineAgentShutdownEvent
 import com.tencent.devops.process.pojo.mq.PipelineBuildLessShutdownDispatchEvent
 import org.springframework.beans.factory.annotation.Autowired
@@ -53,13 +54,15 @@ import java.time.LocalDateTime
  * @version 1.0
  */
 @Component
-class PipelineBuildCancelListener @Autowired constructor(
+class PipelineBuildCancelListener @Autowired(required = false) constructor(
     private val redisOperation: RedisOperation,
     private val pipelineMQEventDispatcher: PipelineEventDispatcher,
     private val buildDetailService: PipelineBuildDetailService,
     private val pipelineRuntimeService: PipelineRuntimeService,
     private val pipelineBuildDetailService: PipelineBuildDetailService,
-    pipelineEventDispatcher: PipelineEventDispatcher
+    pipelineEventDispatcher: PipelineEventDispatcher,
+    @Autowired(required = false)
+    private val measureService: MeasureService?
 ) : BaseListener<PipelineBuildCancelEvent>(pipelineEventDispatcher) {
 
     companion object {
@@ -170,6 +173,8 @@ class PipelineBuildCancelListener @Autowired constructor(
                 status = status
             )
         )
+
+        measureService?.postCancelData(projectId = projectId, pipelineId = pipelineId, buildId = buildId, userId = event.userId)
 
         return true
     }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineVMBuildService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineVMBuildService.kt
@@ -38,7 +38,6 @@ import com.tencent.devops.common.client.Client
 import com.tencent.devops.common.event.dispatcher.pipeline.PipelineEventDispatcher
 import com.tencent.devops.common.event.enums.ActionType
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildStatusBroadCastEvent
-import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildTaskFinishBroadCastEvent
 import com.tencent.devops.common.pipeline.container.VMBuildContainer
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.BuildTaskStatus
@@ -566,17 +565,6 @@ class PipelineVMBuildService @Autowired(required = false) constructor(
             errorMsg = result.message
         )
         pipelineEventDispatcher.dispatch(
-            PipelineBuildTaskFinishBroadCastEvent(
-                source = "build-element-${result.taskId}",
-                projectId = buildInfo.projectId,
-                pipelineId = buildInfo.pipelineId,
-                userId = buildInfo.startUser,
-                buildId = buildInfo.buildId,
-                taskId = result.taskId,
-                errorType = errorType?.name,
-                errorCode = result.errorCode,
-                errorMsg = result.message
-            ),
             PipelineBuildStatusBroadCastEvent(
                 source = "task-end-${result.taskId}",
                 projectId = buildInfo.projectId,
@@ -652,7 +640,8 @@ class PipelineVMBuildService @Autowired(required = false) constructor(
                 executeCount = task.executeCount,
                 errorType = errorType,
                 errorCode = errorCode,
-                errorMsg = errorMsg
+                errorMsg = errorMsg,
+                userId = task.starter
             )
         } catch (t: Throwable) {
             logger.warn("Fail to send the element data", t)

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureService.kt
@@ -43,10 +43,11 @@ interface MeasureService {
         model: Model?,
         errorType: String? = null,
         errorCode: Int? = null,
-        errorMsg: String? = null
+        errorMsg: String? = null,
+        userId: String
     )
 
-    fun postCancelData(projectId: String, pipelineId: String, buildId: String)
+    fun postCancelData(projectId: String, pipelineId: String, buildId: String, userId: String)
 
     fun postTaskData(
         projectId: String,
@@ -62,6 +63,7 @@ interface MeasureService {
         extraInfo: Map<String, Any>? = null,
         errorType: String? = null,
         errorCode: Int? = null,
-        errorMsg: String? = null
+        errorMsg: String? = null,
+        userId: String
     )
 }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureServiceImpl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureServiceImpl.kt
@@ -29,7 +29,9 @@ package com.tencent.devops.process.engine.service.measure
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.api.util.timestampmilli
+import com.tencent.devops.common.event.dispatcher.pipeline.PipelineEventDispatcher
 import com.tencent.devops.common.event.pojo.measure.MeasureRequest
+import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildTaskFinishBroadCastEvent
 import com.tencent.devops.common.pipeline.Model
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.StartType
@@ -44,13 +46,15 @@ import com.tencent.devops.process.utils.PIPELINE_START_PARENT_PIPELINE_ID
 import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
 
+@Suppress("UNUSED")
 class MeasureServiceImpl constructor(
     private val pipelineRuntimeService: PipelineRuntimeService,
     private val pipelineBuildVarDao: PipelineBuildVarDao,
     private val dslContext: DSLContext,
     private val objectMapper: ObjectMapper,
     private val templateService: TemplateService,
-    private val measureEventDispatcher: MeasureEventDispatcher
+    private val measureEventDispatcher: MeasureEventDispatcher,
+    private val pipelineEventDispatcher: PipelineEventDispatcher
 ) : MeasureService {
 
     override fun postPipelineData(
@@ -65,7 +69,8 @@ class MeasureServiceImpl constructor(
         model: Model?,
         errorType: String?,
         errorCode: Int?,
-        errorMsg: String?
+        errorMsg: String?,
+        userId: String
     ) {
         try {
             if (model == null) {
@@ -115,7 +120,7 @@ class MeasureServiceImpl constructor(
         }
     }
 
-    override fun postCancelData(projectId: String, pipelineId: String, buildId: String) {
+    override fun postCancelData(projectId: String, pipelineId: String, buildId: String, userId: String) {
         try {
             val tasks = pipelineRuntimeService.getAllBuildTask(buildId)
             if (tasks.isEmpty()) {
@@ -136,7 +141,8 @@ class MeasureServiceImpl constructor(
                             startTime = tStartTime,
                             status = BuildStatus.CANCELED,
                             type = taskType,
-                            executeCount = executeCount
+                            executeCount = executeCount,
+                            userId = userId
                         )
                     }
                 }
@@ -160,7 +166,8 @@ class MeasureServiceImpl constructor(
         extraInfo: Map<String, Any>?,
         errorType: String?,
         errorCode: Int?,
-        errorMsg: String?
+        errorMsg: String?,
+        userId: String
     ) {
         try {
 
@@ -193,6 +200,20 @@ class MeasureServiceImpl constructor(
                     buildId = buildId,
                     type = MeasureRequest.MeasureType.TASK,
                     request = requestBody
+                )
+            )
+
+            pipelineEventDispatcher.dispatch(
+                PipelineBuildTaskFinishBroadCastEvent(
+                    source = "build-element-$taskId",
+                    projectId = projectId,
+                    pipelineId = pipelineId,
+                    userId = userId,
+                    buildId = buildId,
+                    taskId = taskId,
+                    errorType = errorType,
+                    errorCode = errorCode,
+                    errorMsg = errorMsg
                 )
             )
         } catch (e: Throwable) {


### PR DESCRIPTION
将PipelineBuildTaskFinishBroadCastEvent事件触耦迁移至MeasureService中处理，作为可选项，不影响核心流程。