### PR TITLE
bug:流水线插件全部执行完成后，构建无法自动终止 #927

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureService.kt
@@ -43,8 +43,7 @@ interface MeasureService {
         model: Model?,
         errorType: String? = null,
         errorCode: Int? = null,
-        errorMsg: String? = null,
-        userId: String
+        errorMsg: String? = null
     )
 
     fun postCancelData(projectId: String, pipelineId: String, buildId: String, userId: String)

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureServiceImpl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/measure/MeasureServiceImpl.kt
@@ -69,8 +69,7 @@ class MeasureServiceImpl constructor(
         model: Model?,
         errorType: String?,
         errorCode: Int?,
-        errorMsg: String?,
-        userId: String
+        errorMsg: String?
     ) {
         try {
             if (model == null) {


### PR DESCRIPTION
去掉原新增多余的userId参数