### PR TITLE
fix: 补充所有微服务对接蓝鲸权限中心逻辑 #1318

### DIFF
--- a/src/backend/ci/core/environment/biz-environment-sample/src/main/kotlin/com/tencent/devops/environment/permission/config/EnvironmentPermConfiguration.kt
+++ b/src/backend/ci/core/environment/biz-environment-sample/src/main/kotlin/com/tencent/devops/environment/permission/config/EnvironmentPermConfiguration.kt
@@ -61,7 +61,7 @@ class EnvironmentPermConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
-    fun environmentPermissionService(
+    fun mockEnvironmentPermissionService(
         dslContext: DSLContext,
         envDao: EnvDao,
         authResourceApi: AuthResourceApi,

--- a/src/backend/ci/core/process/biz-process-sample/src/main/kotlin/com/tencent/devops/process/permission/config/PipelinePermConfiguration.kt
+++ b/src/backend/ci/core/process/biz-process-sample/src/main/kotlin/com/tencent/devops/process/permission/config/PipelinePermConfiguration.kt
@@ -64,7 +64,7 @@ class PipelinePermConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
-    fun pipelinePermissionService(
+    fun mockPipelinePermissionService(
         dslContext: DSLContext,
         pipelineInfoDao: PipelineInfoDao,
         authProjectApi: AuthProjectApi,

--- a/src/backend/ci/core/repository/biz-repository-sample/src/main/kotlin/com/tencent/devops/repository/config/RepositoryPermConfiguration.kt
+++ b/src/backend/ci/core/repository/biz-repository-sample/src/main/kotlin/com/tencent/devops/repository/config/RepositoryPermConfiguration.kt
@@ -61,7 +61,7 @@ class RepositoryPermConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
-    fun repositoryPermissionService(
+    fun mockRepositoryPermissionService(
         dslContext: DSLContext,
         repositoryDao: RepositoryDao,
         authResourceApi: AuthResourceApi,

--- a/src/backend/ci/core/ticket/biz-ticket-sample/src/main/kotlin/com/tencent/devops/ticket/config/TicketPermConfiguration.kt
+++ b/src/backend/ci/core/ticket/biz-ticket-sample/src/main/kotlin/com/tencent/devops/ticket/config/TicketPermConfiguration.kt
@@ -77,7 +77,7 @@ class TicketPermConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
-    fun certPermissionService(
+    fun mockCertPermissionService(
         dslContext: DSLContext,
         certDao: CertDao,
         authResourceApi: AuthResourceApi,
@@ -93,7 +93,7 @@ class TicketPermConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
-    fun credentialPermissionService(
+    fun mockCredentialPermissionService(
         dslContext: DSLContext,
         credentialDao: CredentialDao,
         authResourceApi: AuthResourceApi,


### PR DESCRIPTION
使用名称区分，否则会有异常