### PR TITLE
bugfix:开源版插件在quality.json不存在时兼容处理插件的质量红线测试数据 #1349

### DIFF
--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/AtomReleaseServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/AtomReleaseServiceImpl.kt
@@ -555,9 +555,13 @@ abstract class AtomReleaseServiceImpl @Autowired constructor() : AtomReleaseServ
 
                 GetAtomQualityConfigResult("0", arrayOf(""))
             } else {
-                client.get(ServiceQualityIndicatorMarketResource::class).deleteTestIndicator(atomCode)
-                client.get(ServiceQualityMetadataMarketResource::class).deleteTestMetadata(atomCode)
-                client.get(ServiceQualityControlPointMarketResource::class).deleteTestControlPoint(atomCode)
+                try {
+                    client.get(ServiceQualityIndicatorMarketResource::class).deleteTestIndicator(atomCode)
+                    client.get(ServiceQualityMetadataMarketResource::class).deleteTestMetadata(atomCode)
+                    client.get(ServiceQualityControlPointMarketResource::class).deleteTestControlPoint(atomCode)
+                } catch (e: Exception) {
+                    logger.error("clear atom:$atomCode test quality data error", e)
+                }
 
                 GetAtomQualityConfigResult(
                     StoreMessageCode.USER_REPOSITORY_PULL_QUALITY_JSON_FILE_FAIL,


### PR DESCRIPTION
bugfix:开源版插件在quality.json不存在时兼容处理插件的质量红线测试数据 #1349
fix #1349 