### PR TITLE
feature: 优化流水线编辑报错信息 #818

### DIFF
--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/handler/ErrorCodeExceptionMapper.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/handler/ErrorCodeExceptionMapper.kt
@@ -46,7 +46,7 @@ class ErrorCodeExceptionMapper : ExceptionMapper<ErrorCodeException> {
             messageCode = exception.errorCode,
             params = exception.params,
             data = null,
-            defaultMessage = exception.message
+            defaultMessage = exception.defaultMessage
         )
 //        // 在提示信息末尾附加uniqueId定位信息
 //        if (null != errorResult.message && errorResult.message!!.startsWith("[uniqueId=")) {


### PR DESCRIPTION
fix #818 
出现这个问题主要原因是因为错误码没有保存到数据库，导致提示默认信息，默认信息是加了uniqueId这些信息的，现在去掉了uniqueid这些信息。最好错误码也添加到数据库中