### PR TITLE
feat: stage 重试功能接口 #1565

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildService.kt
@@ -324,11 +324,16 @@ class PipelineBuildService(
             val params = mutableMapOf<String, Any>()
             val originVars = buildVariableService.getAllVariable(buildId)
             if (!taskId.isNullOrBlank()) {
-                // job/task级重试，获取buildVariable构建参数，恢复环境变量
+                // stage/job/task级重试，获取buildVariable构建参数，恢复环境变量
                 params.putAll(originVars)
-                // job/task级重试
+                // stage/job/task级重试
                 run {
                     model.stages.forEach { s ->
+                        // stage 级重试
+                        if (s.id == taskId) {
+                            params[PIPELINE_RETRY_START_TASK_ID] = s.id!!
+                            return@run
+                        }
                         s.containers.forEach { c ->
                             val pos = if (c.id == taskId) 0 else -1 // 容器job级别的重试，则找job的第一个原子
                             c.elements.forEachIndexed { index, element ->


### PR DESCRIPTION
当前逻辑是重试的stage所有原子都重新跑, 包括执行成功的
就是原本的retry接口的taskId 传 stageId 例如 stage-2