### PR TITLE
bugfix:网关连接consul和redis超时&请求数量超过最大值&bkrepo不限制频率 issue #1703

### DIFF
--- a/src/gateway/core/lua/router_srv.lua
+++ b/src/gateway/core/lua/router_srv.lua
@@ -129,8 +129,8 @@ end
 
 local dns, err = resolver:new{
   nameservers = dnsIps,
-  retrans = 2,
-  timeout = 250
+  retrans = 5,
+  timeout = 2000
 }
 
 if not dns then

--- a/src/gateway/core/lua/router_srv.lua
+++ b/src/gateway/core/lua/router_srv.lua
@@ -38,7 +38,7 @@ if ngx.var.access_type == 'build' or ngx.var.access_type == 'external' then
 end
 
 -- report服务和bkrepo服务不做频率限制
-if ngx.var.service == 'report' or ngx.var.service == 'bkrepo'then
+if ngx.var.service == 'report' or ngx.var.service == 'bkrepo' then
   access_util = nil
 end
 

--- a/src/gateway/core/lua/router_srv.lua
+++ b/src/gateway/core/lua/router_srv.lua
@@ -37,8 +37,8 @@ if ngx.var.access_type == 'build' or ngx.var.access_type == 'external' then
   access_util = require 'access_control_ip'
 end
 
--- defect服务不做频率限制
-if ngx.var.service == 'report' then
+-- report服务和bkrepo服务不做频率限制
+if ngx.var.service == 'report' or ngx.var.service == 'bkrepo'then
   access_util = nil
 end
 

--- a/src/gateway/core/lua/util/redis_util.lua
+++ b/src/gateway/core/lua/util/redis_util.lua
@@ -32,7 +32,7 @@ function _M:new()
     ngx.log( ngx.ERR, "red new error:", res ,err)
     return nil
   end
-  red:set_timeout(1000) -- 1 second
+  red:set_timeout(2000) -- 2 second
   local res, err  = red:connect(redisConfig['host'], redisConfig['port'])
   if not res then
       ngx.log( ngx.ERR, "red connect error:",redisConfig['host'],",",redisConfig['port']," ", err )

--- a/src/gateway/core/nginx.conf
+++ b/src/gateway/core/nginx.conf
@@ -3,12 +3,12 @@ worker_processes 12;
 
 events {
   # 线上生产环境请一定要修改此参数，在用作网关（反向代理)服务器时，支持的最大连接数=worker_processes*worker_connections/4（一个浏览器两个连接，对内对外乘以4）
-  worker_connections 1024;
+  worker_connections 5120;
 }
 pid        run/nginx.pid;
 
-# 大于worker_processes*worker_connections 1024*16；
-worker_rlimit_nofile 16384;
+# 大于worker_processes*worker_connections 5120*(12+4)；
+worker_rlimit_nofile 81820;
 
 http {
   include       mime.types.conf;


### PR DESCRIPTION
1、修改consul dns请求次数为5次，2秒超时
2、修改redis的连接超时未2秒
3、bkrepo不做频率限制
4、增大nginx的连接数