### PR TITLE
fix: 修复插件和商店选图样式 issue #1798

### DIFF
--- a/src/frontend/devops-atomstore/src/components/common/selectLogo/index.vue
+++ b/src/frontend/devops-atomstore/src/components/common/selectLogo/index.vue
@@ -279,7 +279,6 @@
                 height: 32px;
                 padding-bottom: 19px;
                 box-sizing: content-box;
-                border-bottom: 1px dotted $lightColor;
                 .input-file {
                     position: absolute;
                     left: 0;

--- a/src/frontend/devops-pipeline/src/components/AtomFormComponent/Tips/index.vue
+++ b/src/frontend/devops-pipeline/src/components/AtomFormComponent/Tips/index.vue
@@ -1,7 +1,7 @@
 <template>
     <h3 class="component-tip">
         <span class="tip-icon">
-            <i class="bk-icon icon-info-circle-shape"></i>
+            <i class="devops-icon icon-info-circle-shape"></i>
         </span>
         <span class="tip-message" v-html="tip"></span>
     </h3>


### PR DESCRIPTION
- tip插件icon样式
- 商店选择图片多了一个线