### PR TITLE
bugfix: 插件设置“失败时继续”后，若执行超时，流水线状态不正确 #1526

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
@@ -393,7 +393,7 @@ class ContainerControl @Autowired constructor(
                     pipelineBuildDetailService.taskEnd(
                         buildId = task.buildId,
                         taskId = task.taskId,
-                        buildStatus = task.status,
+                        buildStatus = containerFinalStatus,
                         canRetry = true,
                         errorType = ErrorType.SYSTEM,
                         errorCode = ErrorCode.SYSTEM_WORKER_INITIALIZATION_ERROR,


### PR DESCRIPTION
fix: #1526 