### PR TITLE
bug: 开源默认的归档插件中对归档文件的所在路径分隔符统一转换为Unix格式 #1818

### DIFF
--- a/src/backend/ci/core/worker/worker-api-sdk/src/main/kotlin/com/tencent/devops/worker/common/api/archive/ArchiveResourceApi.kt
+++ b/src/backend/ci/core/worker/worker-api-sdk/src/main/kotlin/com/tencent/devops/worker/common/api/archive/ArchiveResourceApi.kt
@@ -51,7 +51,7 @@ class ArchiveResourceApi : AbstractBuildResourceApi(), ArchiveSDKApi {
         customFilePath: String?
     ): List<String> {
         val purePath = if (customFilePath != null) {
-            purePath(customFilePath).toString()
+            purePath(customFilePath)
         } else {
             customFilePath
         }
@@ -80,7 +80,7 @@ class ArchiveResourceApi : AbstractBuildResourceApi(), ArchiveSDKApi {
 
     override fun uploadCustomize(file: File, destPath: String, buildVariables: BuildVariables) {
         // 过滤掉用../尝试遍历上层目录的操作
-        val purePath = purePath(destPath).toString()
+        val purePath = purePath(destPath)
         val path = purePath + "/" + file.name
         LoggerService.addNormalLine("upload file >>> $path")
 

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/api/AbstractBuildResourceApi.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/api/AbstractBuildResourceApi.kt
@@ -304,12 +304,12 @@ abstract class AbstractBuildResourceApi : WorkerRestApiSDK {
             .replace("=", "%5C=")
     }
 
-    fun purePath(destPath: String): Path {
+    fun purePath(destPath: String): String {
         return Paths.get(
             destPath.removeSuffix("/")
                 .replace("./", "/")
                 .replace("../", "/")
                 .replace("//", "/")
-        )!!
+        ).toString().replace("\\", "/") // 保证win/Unix平台兼容性统一转为/分隔文件路径
     }
 }

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/api/AbstractBuildResourceApi.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/api/AbstractBuildResourceApi.kt
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URLEncoder
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.cert.CertificateException
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
 保证win/Unix平台兼容性统一转为/分隔文件路径