### PR TITLE
bug: 开源默认的归档插件中对归档文件的所在路径分隔符统一转换为Unix格式 #1818

### DIFF
--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/api/AbstractBuildResourceApi.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/api/AbstractBuildResourceApi.kt
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URLEncoder
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.cert.CertificateException
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
 format