### PR TITLE
perf: 错误日志修复 #1426

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineWebhookService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineWebhookService.kt
@@ -201,7 +201,7 @@ class PipelineWebhookService @Autowired constructor(
     }
 
     fun getModel(pipelineId: String, version: Int? = null): Model? {
-        val modelString = pipelineResDao.getVersionModelString(dslContext, pipelineId, version)
+        val modelString = pipelineResDao.getVersionModelString(dslContext, pipelineId, version) ?: return null
         return try {
             objectMapper.readValue(modelString, Model::class.java)
         } catch (e: Exception) {


### PR DESCRIPTION
fix #1426 

当流水线被删除后，触发webhook时，因为webhook的流水线ID会保留到redis，流水线删除但是redis没有删除，会导致空指针错误