### PR TITLE
feature:调整网关的频率限制 #2006

### DIFF
--- a/src/gateway/core/lua/access_control_ip.lua
+++ b/src/gateway/core/lua/access_control_ip.lua
@@ -25,9 +25,9 @@ function _M:isAccess()
     -- 外部请求频率50,浮动20；构建机类请求频率20，浮动20
     local lim = nil
     if ngx.var.access_type == 'external' then
-        lim, err = limit_req.new("build_limit_req_store", 50, 20)
+        lim, err = limit_req.new("build_limit_req_store", 100, 50)
     else
-        lim, err = limit_req.new("build_limit_req_store", 20, 20)
+        lim, err = limit_req.new("build_limit_req_store", 100, 20)
     end
     -- 创建req_limit实例失败时
     if not lim then

--- a/src/gateway/core/lua/router_srv.lua
+++ b/src/gateway/core/lua/router_srv.lua
@@ -38,7 +38,7 @@ if ngx.var.access_type == 'build' or ngx.var.access_type == 'external' then
 end
 
 -- report服务和bkrepo服务不做频率限制
-if ngx.var.service == 'report' or ngx.var.service == 'bkrepo' then
+if ngx.var.service == 'report' or ngx.var.service == 'bkrepo' or ngx.var.service == 'schedule' or ngx.var.service == 'task' then
   access_util = nil
 end
 


### PR DESCRIPTION
1、report、bkrepo、schedule、task模块不做频率限制
2、build和external类请求，频率限制到每秒100次，浮动50.