### PR TITLE
perf: 被禁用或跳过的[无用]插件任务在启动构建时不需要存储 #2046

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
@@ -342,7 +342,7 @@ class ContainerControl @Autowired constructor(
                 !startVMFail && !ActionType.isEnd(actionType) && BuildStatus.isReadyToRun(finallyTasks[0].status) -> return finallyTasks[0] to ActionType.START
                 BuildStatus.isReadyToRun(finallyTasks[1].status) -> {
                     // 先将排队状态下的Hold点移出待执行状态，置为未执行。 对于插件执行失败的(非构建机启动失败），构建机已经将Hold点置为完成，所以不能再重置为未执行
-                    if (startVMFail && BuildStatus.isReadyToRun(finallyTasks[0].status)) {
+                    if (BuildStatus.isReadyToRun(finallyTasks[0].status)) {
                         pipelineRuntimeService.updateTaskStatus(buildId = buildId, taskId = finallyTasks[0].taskId, userId = userId, buildStatus = BuildStatus.UNEXEC)
                     }
                     return finallyTasks[1] to ActionType.START // 再拿停止构建机


### PR DESCRIPTION
修正：解决已经执行过的end-xxxx拦截点又被重新置为UNEXEC

#2046