### PR TITLE
流水线存在并行Container会存在setEnv失效bug #954

### DIFF
--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/script/ScriptEnvUtils.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/script/ScriptEnvUtils.kt
@@ -26,6 +26,7 @@
 
 package com.tencent.devops.worker.common.task.script
 
+import com.tencent.devops.worker.common.utils.ExecutorUtil
 import org.slf4j.LoggerFactory
 import java.io.File
 
@@ -43,7 +44,8 @@ object ScriptEnvUtils {
     }
 
     fun getEnvFile(buildId: String): String {
-        return "$buildId-$ENV_FILE"
+        val randomNum = ExecutorUtil.getThreadLocal()
+        return "$buildId-$randomNum-$ENV_FILE"
     }
 
     fun getQualityGatewayEnvFile() = QUALITY_GATEWAY_FILE

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/script/ScriptTask.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/script/ScriptTask.kt
@@ -40,6 +40,7 @@ import com.tencent.devops.worker.common.logger.LoggerService
 import com.tencent.devops.worker.common.task.ITask
 import com.tencent.devops.worker.common.task.script.bat.WindowsScriptTask
 import com.tencent.devops.worker.common.utils.ArchiveUtils
+import com.tencent.devops.worker.common.utils.ExecutorUtil
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URLDecoder
@@ -108,6 +109,7 @@ open class ScriptTask : ITask() {
         } finally {
             // 成功失败都写入环境变量
             addEnv(ScriptEnvUtils.getEnv(buildId, workspace))
+            ExecutorUtil.removeThreadLocal()
         }
 
         // 设置质量红线指标信息

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/ExecutorUtil.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/ExecutorUtil.kt
@@ -90,4 +90,8 @@ object ExecutorUtil {
         }
         return threadLocal.get()
     }
+
+    fun removeThreadLocal() {
+        threadLocal.remove()
+    }
 }

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/ExecutorUtil.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/ExecutorUtil.kt
@@ -35,9 +35,12 @@ import org.apache.commons.exec.DefaultExecutor
 import org.apache.commons.exec.LogOutputStream
 import org.apache.commons.exec.PumpStreamHandler
 import java.io.File
+import java.util.concurrent.ThreadLocalRandom
 
 object ExecutorUtil {
     private val executor = DefaultExecutor()
+
+    private val threadLocal = ThreadLocal<String>()
 
     fun runCommand(command: String, maskCommand: String, workDir: File? = null): Int {
         val outputStream = object : LogOutputStream() {
@@ -73,5 +76,18 @@ object ExecutorUtil {
         }
         LoggerService.addNormalLine("Finish the command, exitValue=$exitValue")
         return exitValue
+    }
+
+    private fun setThreadLocal() {
+        val randomNum = ThreadLocalRandom.current().nextInt().toString()
+        threadLocal.set(randomNum)
+    }
+
+    fun getThreadLocal(): String {
+        val value = threadLocal.get()
+        if (value == null) {
+            setThreadLocal()
+        }
+        return threadLocal.get()
     }
 }


### PR DESCRIPTION
构建机操作文件添加随机数，做到并行Container 间的隔离， 避免误写误读