### PR TITLE
开源版的gateway不用开启jwt验证 #2201

### DIFF
--- a/src/backend/ci/core/common/common-security/src/main/kotlin/com/tencent/devops/common/security/jwt/JwtManager.kt
+++ b/src/backend/ci/core/common/common-security/src/main/kotlin/com/tencent/devops/common/security/jwt/JwtManager.kt
@@ -137,7 +137,7 @@ class JwtManager(
     }
 
     init {
-        if (!enable || privateKeyString.isNullOrBlank() || publicKeyString.isNullOrBlank()) {
+        if (privateKeyString.isNullOrBlank() || publicKeyString.isNullOrBlank()) {
             privateKey = null
             publicKey = null
             authEnable = false


### PR DESCRIPTION
这里enable只是在自己作为消费端时, 判断"是否需要解析jwt" 

而自己作为生产端时, 是否需要jwt加密, 是根据privateKey和publicKey来判断