### PR TITLE
bug: github webhook事件GithubUser对象中的username是可以为空 #2450

### DIFF
--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/code/github/GithubEvent.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/code/github/GithubEvent.kt
@@ -47,7 +47,7 @@ data class GithubCommit(
 data class GithubUser(
     val name: String,
     val email: String,
-    val username: String
+    val username: String? = null
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
当git客户端中的user.name设置和github中的用户名不一致时,username这个字段就会为空,触发流水线时就会报错
#2450 