### PR TITLE
bug: 重试时导致后续能满足条件才运行的插件被意外跳过 #2400

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/TaskControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/TaskControl.kt
@@ -40,7 +40,6 @@ import com.tencent.devops.process.engine.service.PipelineRuntimeService
 import com.tencent.devops.process.pojo.mq.PipelineBuildContainerEvent
 import com.tencent.devops.process.service.PipelineTaskService
 import org.slf4j.LoggerFactory
-import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/TaskControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/TaskControl.kt
@@ -51,7 +51,6 @@ import org.springframework.stereotype.Service
 @Service
 class TaskControl @Autowired constructor(
     private val redisOperation: RedisOperation,
-    private val rabbitTemplate: RabbitTemplate,
     private val taskAtomService: TaskAtomService,
     private val pipelineEventDispatcher: PipelineEventDispatcher,
     private val pipelineRuntimeService: PipelineRuntimeService,
@@ -104,9 +103,10 @@ class TaskControl @Autowired constructor(
         logger.info("[$buildId]|[${buildInfo.status}]|ATOM_$actionType|taskId=$taskId|status=${buildTask.status}")
         val buildStatus = when {
             BuildStatus.isReadyToRun(buildTask.status) -> { // 准备启动执行
-                if (ActionType.isEnd(actionType)) {
-                    pipelineRuntimeService.updateTaskStatus(buildId, taskId, userId, BuildStatus.SKIP)
-                    BuildStatus.SKIP // 未执行的原子设置为SKIP或UNEXEC
+                if (ActionType.isEnd(actionType)) { // #2400 因任务终止&结束的事件命令而未执行的原子设置为UNEXEC，而不是SKIP
+                    pipelineRuntimeService.updateTaskStatus(buildId, taskId, userId, BuildStatus.UNEXEC)
+
+                    BuildStatus.UNEXEC // SKIP 仅当是用户意愿明确正常运行情况要跳过执行的，不影响主流程的才能是SKIP
                 } else {
                     atomBuildStatus(taskAtomService.start(buildTask))
                 }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineVMBuildService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineVMBuildService.kt
@@ -379,8 +379,13 @@ class PipelineVMBuildService @Autowired(required = false) constructor(
                         ) {
                             if (!ControlUtils.checkCustomVariableSkip(buildId = buildId, additionalOptions = additionalOptions, variables = allVariable)) {
                                 queueTasks.add(task)
-                            } else {
-                                pipelineBuildDetailService.taskSkip(buildId, task.taskId)
+                                /* #2400 此处逻辑有问题不能在这直接设置Model为跳过：
+                                    举例按顺序 Job2 下的Task1 和 Task2 插件都未开始执行， Task2设置为指定条件执行，但条件依赖于Task1生成。
+                                    1. Task1正常执行并结束情况下，但执行过程中影响展示上在Task1执行时会提前将Task2设置为跳过，存在误导，但Task1结束后，只要条件满足，Task2仍然会执行
+                                    2. Task1失败了，导致条件没设置成功，构建结束。 此时进行重试，Task1重试成功了，条件也设置成功了， 但Task2仍然为SKIP（在启动时就决定了）
+                                 */
+//                            } else {
+//                                pipelineBuildDetailService.taskSkip(buildId, task.taskId)
                             }
                         }
                     }


### PR DESCRIPTION
fix #2400 
明确UNEXEC与SKIP的用途
UNEXEC  仅因为系统平台或用户的构建脚本导致的出错，导致构建需要进行终止时，后续未执行的插件（从QUEUE-->UNEXEC）
SKIP 仅当是用户意愿明确正常运行情况要跳过执行的，不影响主流程的才能是SKIP