### PR TITLE
perf: 日志模块采用Rest Client方式访问ES #2596

### DIFF
--- a/src/backend/ci/core/common/common-es/src/main/kotlin/com/tencent/devops/common/es/ESAutoConfiguration.kt
+++ b/src/backend/ci/core/common/common-es/src/main/kotlin/com/tencent/devops/common/es/ESAutoConfiguration.kt
@@ -65,7 +65,7 @@ class ESAutoConfiguration : DisposableBean {
     private val username: String? = null
     @Value("\${elasticsearch.password:#{null}}")
     private val password: String? = null
-    @Value("\${elasticsearch.https}")
+    @Value("\${elasticsearch.https:#{null}}")
     private val https: String? = null
     @Value("\${elasticsearch.keystore.filePath:#{null}}")
     private val keystoreFilePath: String? = null


### PR DESCRIPTION
修复elasticsearch.https不可为空