### PR TITLE
chore: 梳理前端登录跳转路径拼接逻辑 issue#2640

### DIFF
--- a/src/frontend/devops-nav/src/index.html
+++ b/src/frontend/devops-nav/src/index.html
@@ -197,13 +197,17 @@
     <script>
         
         window.getLoginUrl = function () {
-            var c_url = location.origin + location.pathname + encodeURIComponent(location.search)
+            var cUrl = location.origin + location.pathname + encodeURIComponent(location.search)
             if (/=%s/.test(LOGIN_SERVICE_URL)) { 
-                return LOGIN_SERVICE_URL.replace(/%s/, c_url)
-            } else if (/\?/.test(LOGIN_SERVICE_URL)) { 
-                LOGIN_SERVICE_URL =  LOGIN_SERVICE_URL + '&c_url=' + c_url
-            } else {
-                return LOGIN_SERVICE_URL =  LOGIN_SERVICE_URL + '?c_url=' + c_url
+                return LOGIN_SERVICE_URL.replace(/%s/, cUrl)
+            }else {
+                const loginUrl = new URL(LOGIN_SERVICE_URL)
+                if (/=$/.test(loginUrl.search)) {
+                  return LOGIN_SERVICE_URL + cUrl
+                } else {
+                  loginUrl.searchParams.append('c_url', cUrl)
+                  return loginUrl.href
+                }
             }
             return LOGIN_SERVICE_URL
         }


### PR DESCRIPTION
登录路径逻辑：
1、若有%s，则替换%s
2、如果参数为空：直接追加 ?c_url=ci_url
3、有参数且=结尾，则直接添加ci_url
4、有参数非=结尾，添加&c_url=ci_url

