### PR TITLE
bugfix: 获取日志为空问题 #2318

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/enums/BuildStatus.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/enums/BuildStatus.kt
@@ -60,6 +60,26 @@ enum class BuildStatus(val statusName: String, val visiable: Boolean) {
     DEPENDENT_WAITING("依赖等待", true), // 24 依赖等待
     UNKNOWN("未知状态", false); // 99
 
+    fun isFinish(): Boolean = isFinish(this)
+
+    fun isFailure(): Boolean = isFailure(this)
+
+    fun isSuccess(): Boolean = isSuccess(this)
+
+    fun isRunning(): Boolean = isRunning(this)
+
+    fun isCancel(): Boolean = isCancel(this)
+
+    fun isReview(): Boolean = isReview(this)
+
+    fun isReadyToRun(): Boolean = isReadyToRun(this)
+
+    fun isLoop(): Boolean = isLoop(this)
+
+    fun isRetry(): Boolean = isRetry(this)
+
+    fun isTimeout(): Boolean = isTimeout(this)
+
     companion object {
 
         fun parse(statusName: String?): BuildStatus {
@@ -86,6 +106,7 @@ enum class BuildStatus(val statusName: String, val visiable: Boolean) {
         fun isReview(status: BuildStatus) = status == REVIEW_ABORT || status == REVIEW_PROCESSED
 
         fun isReadyToRun(status: BuildStatus) = status == QUEUE || status == QUEUE_CACHE || isRetry(status)
+
         /**
          * 是否处于循环中： 正在运行中或循环等待都属于循环
          */


### PR DESCRIPTION
原则：当存在多个失败插件时，进行失败插件重试时，一次只能对单个插件进行重试，其他失败插件不会重试，所以：
如果是插件失败重试，并且当前的Job状态是失败的，则检查重试的插件是不是属于该失败Job:
如果不属于，则表示该Job在本次重试不会被执行到，则不做处理，保持原状态, 跳过

#2318