### PR TITLE
fix: 构建机启动时间超过120秒时会导致Agent心跳超时判定消息事件提前结束 #2365

### DIFF
--- a/src/backend/ci/core/process/biz-process-sample/src/main/kotlin/com/tencent/devops/process/service/PipelineBuildExtServiceImpl.kt
+++ b/src/backend/ci/core/process/biz-process-sample/src/main/kotlin/com/tencent/devops/process/service/PipelineBuildExtServiceImpl.kt
@@ -1,3 +1,29 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package com.tencent.devops.process.service
 
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/builds/BuildBuildResourceImpl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/builds/BuildBuildResourceImpl.kt
@@ -49,12 +49,12 @@ class BuildBuildResourceImpl @Autowired constructor(
 ) : BuildBuildResource {
 
     override fun setStarted(buildId: String, vmSeqId: String, vmName: String): Result<BuildVariables> {
-        Companion.checkParam(buildId, vmSeqId, vmName)
+        checkParam(buildId, vmSeqId, vmName)
         return Result(vmBuildService.buildVMStarted(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
     override fun claimTask(buildId: String, vmSeqId: String, vmName: String): Result<BuildTask> {
-        Companion.checkParam(buildId, vmSeqId, vmName)
+        checkParam(buildId, vmSeqId, vmName)
         return Result(vmBuildService.buildClaimTask(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
@@ -64,13 +64,13 @@ class BuildBuildResourceImpl @Autowired constructor(
         vmName: String,
         result: BuildTaskResult
     ): Result<Boolean> {
-        Companion.checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
+        checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
         vmBuildService.buildCompleteTask(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName, result = result)
         return Result(true)
     }
 
     override fun endTask(buildId: String, vmSeqId: String, vmName: String): Result<Boolean> {
-        Companion.checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
+        checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
         return Result(vmBuildService.buildEndTask(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
@@ -92,7 +92,7 @@ class BuildBuildResourceImpl @Autowired constructor(
     }
 
     override fun heartbeat(buildId: String, vmSeqId: String, vmName: String): Result<Boolean> {
-        Companion.checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
+        checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
         return Result(data = vmBuildService.heartbeat(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/builds/BuildBuildResourceImpl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/builds/BuildBuildResourceImpl.kt
@@ -49,12 +49,12 @@ class BuildBuildResourceImpl @Autowired constructor(
 ) : BuildBuildResource {
 
     override fun setStarted(buildId: String, vmSeqId: String, vmName: String): Result<BuildVariables> {
-        checkParam(buildId, vmSeqId, vmName)
+        Companion.checkParam(buildId, vmSeqId, vmName)
         return Result(vmBuildService.buildVMStarted(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
     override fun claimTask(buildId: String, vmSeqId: String, vmName: String): Result<BuildTask> {
-        checkParam(buildId, vmSeqId, vmName)
+        Companion.checkParam(buildId, vmSeqId, vmName)
         return Result(vmBuildService.buildClaimTask(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
@@ -64,17 +64,22 @@ class BuildBuildResourceImpl @Autowired constructor(
         vmName: String,
         result: BuildTaskResult
     ): Result<Boolean> {
-        checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
+        Companion.checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
         vmBuildService.buildCompleteTask(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName, result = result)
         return Result(true)
     }
 
     override fun endTask(buildId: String, vmSeqId: String, vmName: String): Result<Boolean> {
-        checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
+        Companion.checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
         return Result(vmBuildService.buildEndTask(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
-    override fun timeoutTheBuild(projectId: String, pipelineId: String, buildId: String, vmSeqId: String): Result<Boolean> {
+    override fun timeoutTheBuild(
+        projectId: String,
+        pipelineId: String,
+        buildId: String,
+        vmSeqId: String
+    ): Result<Boolean> {
         return Result(
             data = vmBuildService.setStartUpVMStatus(
                 projectId = projectId,
@@ -87,7 +92,7 @@ class BuildBuildResourceImpl @Autowired constructor(
     }
 
     override fun heartbeat(buildId: String, vmSeqId: String, vmName: String): Result<Boolean> {
-        checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
+        Companion.checkParam(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName)
         return Result(data = vmBuildService.heartbeat(buildId = buildId, vmSeqId = vmSeqId, vmName = vmName))
     }
 
@@ -98,7 +103,12 @@ class BuildBuildResourceImpl @Autowired constructor(
         channelCode: ChannelCode?
     ): Result<BuildHistory?> {
         return Result(
-            data = buildService.getSingleHistoryBuild(projectId = projectId, pipelineId = pipelineId, buildNum = buildNum.toInt(), channelCode = channelCode ?: ChannelCode.BS)
+            data = buildService.getSingleHistoryBuild(
+                projectId = projectId,
+                pipelineId = pipelineId,
+                buildNum = buildNum.toInt(),
+                channelCode = channelCode ?: ChannelCode.BS
+            )
         )
     }
 
@@ -107,7 +117,13 @@ class BuildBuildResourceImpl @Autowired constructor(
         pipelineId: String,
         channelCode: ChannelCode?
     ): Result<BuildHistory?> {
-        return Result(data = buildService.getLatestSuccessBuild(projectId = projectId, pipelineId = pipelineId, channelCode = channelCode ?: ChannelCode.BS))
+        return Result(
+            data = buildService.getLatestSuccessBuild(
+                projectId = projectId,
+                pipelineId = pipelineId,
+                channelCode = channelCode ?: ChannelCode.BS
+            )
+        )
     }
 
     override fun getBuildDetail(
@@ -120,8 +136,12 @@ class BuildBuildResourceImpl @Autowired constructor(
             throw ParamBlankException("Invalid buildId")
         }
         return Result(
-            buildService.getBuildDetail(
-                projectId = projectId, pipelineId = pipelineId, buildId = buildId, channelCode = channelCode, checkPermission = ChannelCode.isNeedAuth(channelCode)
+            data = buildService.getBuildDetail(
+                projectId = projectId,
+                pipelineId = pipelineId,
+                buildId = buildId,
+                channelCode = channelCode,
+                checkPermission = ChannelCode.isNeedAuth(channelCode)
             )
         )
     }
@@ -130,15 +150,17 @@ class BuildBuildResourceImpl @Autowired constructor(
         return subPipelineStartUpService.getSubVar(buildId = buildId, taskId = taskId)
     }
 
-    private fun checkParam(buildId: String, vmSeqId: String, vmName: String) {
-        if (buildId.isBlank()) {
-            throw ParamBlankException("Invalid buildId")
-        }
-        if (vmSeqId.isBlank()) {
-            throw ParamBlankException("Invalid vmSeqId")
-        }
-        if (vmName.isBlank()) {
-            throw ParamBlankException("Invalid vmName")
+    companion object {
+        private fun checkParam(buildId: String, vmSeqId: String, vmName: String) {
+            if (buildId.isBlank()) {
+                throw ParamBlankException("Invalid buildId")
+            }
+            if (vmSeqId.isBlank()) {
+                throw ParamBlankException("Invalid vmSeqId")
+            }
+            if (vmName.isBlank()) {
+                throw ParamBlankException("Invalid vmName")
+            }
         }
     }
 }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchBuildLessDockerStartupTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchBuildLessDockerStartupTaskAtom.kt
@@ -49,7 +49,6 @@ import com.tencent.devops.process.engine.atom.IAtomTask
 import com.tencent.devops.process.engine.common.VMUtils
 import com.tencent.devops.process.engine.exception.BuildTaskException
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask
-import com.tencent.devops.process.engine.pojo.event.PipelineContainerAgentHeartBeatEvent
 import com.tencent.devops.process.engine.service.PipelineBuildDetailService
 import com.tencent.devops.process.engine.service.PipelineRepositoryService
 import com.tencent.devops.common.api.pojo.ErrorCode
@@ -196,14 +195,6 @@ class DispatchBuildLessDockerStartupTaskAtom @Autowired constructor(
                 zone = getBuildZone(container),
                 atoms = atoms,
                 executeCount = task.executeCount
-            ),
-            PipelineContainerAgentHeartBeatEvent(
-                source = source,
-                projectId = projectId,
-                pipelineId = pipelineId,
-                userId = task.starter,
-                buildId = buildId,
-                containerId = task.containerId
             )
         )
         logger.info("[$buildId]|STARTUP_DOCKER|($vmSeqId)|Dispatch startup")

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMStartupTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMStartupTaskAtom.kt
@@ -57,7 +57,6 @@ import com.tencent.devops.process.engine.atom.parser.DispatchTypeParser
 import com.tencent.devops.process.engine.common.VMUtils
 import com.tencent.devops.process.engine.exception.BuildTaskException
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask
-import com.tencent.devops.process.engine.pojo.event.PipelineContainerAgentHeartBeatEvent
 import com.tencent.devops.process.engine.service.PipelineBuildDetailService
 import com.tencent.devops.process.engine.service.PipelineRepositoryService
 import com.tencent.devops.process.engine.service.PipelineRuntimeService
@@ -231,14 +230,6 @@ class DispatchVMStartupTaskAtom @Autowired constructor(
                 containerId = task.containerId,
                 containerHashId = task.containerHashId,
                 containerType = task.containerType
-            ),
-            PipelineContainerAgentHeartBeatEvent(
-                source = source,
-                projectId = projectId,
-                pipelineId = pipelineId,
-                userId = task.starter,
-                buildId = buildId,
-                containerId = task.containerId
             )
         )
         logger.info("[$buildId]|STARTUP_VM|VM=${param.baseOS}-$vmNames($vmSeqId)|Dispatch startup")

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/HeartbeatControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/HeartbeatControl.kt
@@ -1,0 +1,167 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.devops.process.engine.control
+
+import com.tencent.devops.common.event.dispatcher.pipeline.PipelineEventDispatcher
+import com.tencent.devops.common.event.enums.ActionType
+import com.tencent.devops.common.log.utils.BuildLogPrinter
+import com.tencent.devops.common.pipeline.utils.HeartBeatUtils
+import com.tencent.devops.common.redis.RedisOperation
+import com.tencent.devops.process.engine.pojo.BuildInfo
+import com.tencent.devops.process.engine.pojo.event.PipelineContainerAgentHeartBeatEvent
+import com.tencent.devops.process.engine.service.PipelineRuntimeService
+import com.tencent.devops.process.pojo.mq.PipelineBuildContainerEvent
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+@Service
+class HeartbeatControl @Autowired constructor(
+    private val buildLogPrinter: BuildLogPrinter,
+    private val redisOperation: RedisOperation,
+    private val pipelineEventDispatcher: PipelineEventDispatcher,
+    private val pipelineRuntimeService: PipelineRuntimeService
+) {
+
+    companion object {
+        private const val REDIS_EXPIRED_MIN = 30L // redis expired time in 30 minutes
+        private const val TIMEOUT_IN_MS = 2 * 60 * 1000 // timeout in 2 minutes
+        private val logger = LoggerFactory.getLogger(HeartbeatControl::class.java)
+    }
+
+    fun detectHeartbeat(event: PipelineContainerAgentHeartBeatEvent) {
+        val lastUpdate = redisOperation.get(HeartBeatUtils.genHeartBeatKey(event.buildId, event.containerId))
+            ?: run {
+                logger.info("[${event.buildId}]|HEART_BEAT_MONITOR_CANCEL|Job#${event.containerId}")
+                return
+            }
+
+        val buildInfo = pipelineRuntimeService.getBuildInfo(event.buildId)
+        if (buildInfo == null || buildInfo.status.isFinish()) {
+            logger.info("[${event.buildId}]|HEART_BEAT_MONITOR_FINISH|The build has been finish(${buildInfo?.status})")
+            return
+        }
+
+        val elapse = System.currentTimeMillis() - lastUpdate.toLong()
+        if (elapse > TIMEOUT_IN_MS) {
+            logger.warn("[${event.buildId}]|HEART_BEAT_MONITOR_OT|The build is timeout for ${elapse}ms, terminate it")
+
+            val container = pipelineRuntimeService.getContainer(buildId = event.buildId,
+                stageId = null, containerId = event.containerId)
+                ?: run {
+                    logger.warn("[${event.buildId}]|HEART_BEAT_MONITOR_EXIT|can not find Job#${event.containerId}")
+                    return
+                }
+
+            var found = false
+            // #2365 在运行中的插件中记录心跳超时信息
+            val runningTask =
+                pipelineRuntimeService.getRunningTask(projectId = event.projectId, buildId = event.buildId)
+            runningTask.forEach { taskMap ->
+                if (event.containerId == taskMap["containerId"] && taskMap["taskId"] != null) {
+                    found = true
+                    val executeCount = taskMap["executeCount"]?.toString()?.toInt() ?: 1
+                    buildLogPrinter.addRedLine(
+                        buildId = event.buildId,
+                        message =
+                        "Agent心跳超时/Agent's heartbeat has been lost(${TimeUnit.MILLISECONDS.toSeconds(elapse)} sec)",
+                        tag = taskMap["taskId"].toString(),
+                        jobId = event.containerId,
+                        executeCount = executeCount
+                    )
+                }
+            }
+
+            if (!found) {
+                // #2365 在Set Up Job位置记录心跳超时信息
+                buildLogPrinter.addRedLine(
+                    buildId = event.buildId,
+                    message =
+                    "Agent心跳超时/Agent's heartbeat has been lost(${TimeUnit.MILLISECONDS.toSeconds(elapse)} sec)",
+                    tag = com.tencent.devops.process.engine.common.VMUtils.genStartVMTaskId(event.containerId),
+                    jobId = event.containerId,
+                    executeCount = container.executeCount
+                )
+            }
+
+            // 终止当前容器下的任务
+            pipelineEventDispatcher.dispatch(
+                PipelineBuildContainerEvent(
+                    source = "heartbeat_timeout",
+                    projectId = event.projectId,
+                    pipelineId = event.pipelineId,
+                    userId = event.userId,
+                    buildId = event.buildId,
+                    stageId = container.stageId,
+                    containerId = event.containerId,
+                    containerType = container.containerType,
+                    actionType = ActionType.TERMINATE,
+                    reason = "构建任务对应的Agent的心跳超时，请检查Agent的状态"
+                )
+            )
+        } else {
+            logger.info("[${event.buildId}]|HEART_BEAT_MONITOR_LOOP|${event.source}|Job#${event.containerId}")
+            // 正常是继续循环检查当前消息
+            pipelineEventDispatcher.dispatch(event)
+        }
+    }
+
+    fun addHeartBeat(buildId: String, vmSeqId: String, time: Long, retry: Int = 3) {
+        try {
+            redisOperation.set(
+                key = HeartBeatUtils.genHeartBeatKey(buildId = buildId, vmSeqId = vmSeqId),
+                value = time.toString(),
+                expiredInSecond = TimeUnit.MINUTES.toSeconds(REDIS_EXPIRED_MIN)
+            )
+        } catch (ignored: Throwable) {
+            if (retry > 0) {
+                logger.warn("[$buildId]|Fail to set heart beat variable(Job#$vmSeqId -> $time)", ignored)
+                addHeartBeat(buildId = buildId, vmSeqId = vmSeqId, time = time, retry = retry - 1)
+            } else {
+                throw ignored
+            }
+        }
+    }
+
+    fun dispatchHeartbeatEvent(buildInfo: BuildInfo, containerId: String) {
+        pipelineEventDispatcher.dispatch(
+            PipelineContainerAgentHeartBeatEvent(
+                source = "buildVMStarted",
+                projectId = buildInfo.projectId,
+                pipelineId = buildInfo.pipelineId,
+                userId = buildInfo.startUser,
+                buildId = buildInfo.buildId,
+                containerId = containerId
+            )
+        )
+    }
+
+    fun dropHeartbeat(buildId: String, vmSeqId: String) {
+        redisOperation.delete(HeartBeatUtils.genHeartBeatKey(buildId, vmSeqId))
+    }
+}

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildExtService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildExtService.kt
@@ -1,3 +1,29 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package com.tencent.devops.process.engine.service
 
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildService.kt
@@ -1525,7 +1525,7 @@ class PipelineBuildService(
                 )
             }
 
-            if (tasks.isNotEmpty()) {
+            if (tasks.isEmpty()) {
                 buildLogPrinter.addYellowLine(
                     buildId = buildId,
                     message = "流水线被用户终止，操作人:$userId",


### PR DESCRIPTION
fix: 构建机启动时间超过120秒时会导致Agent心跳超时判定消息事件提前结束 #2365

将心跳事件监听事件的触发从构建机开始上报构建机准备就绪开始