### PR TITLE
fix: 迁移github触发器相关接口 #3006

### DIFF
--- a/src/backend/ci/core/repository/api-repository/src/main/kotlin/com/tencent/devops/repository/api/UserGithubResource.kt
+++ b/src/backend/ci/core/repository/api-repository/src/main/kotlin/com/tencent/devops/repository/api/UserGithubResource.kt
@@ -71,4 +71,9 @@ interface UserGithubResource {
         @QueryParam("userId")
         userId: String
     ): Result<Boolean>
+
+    @ApiOperation("获取github触发原子配置")
+    @GET
+    @Path("/githubAppUrl")
+    fun getGithubAppUrl(): Result<String>
 }

--- a/src/backend/ci/core/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/resources/UserGithubResourceImpl.kt
+++ b/src/backend/ci/core/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/resources/UserGithubResourceImpl.kt
@@ -30,6 +30,7 @@ import com.tencent.devops.common.api.pojo.Result
 import com.tencent.devops.common.web.RestResource
 import com.tencent.devops.repository.api.UserGithubResource
 import com.tencent.devops.repository.pojo.AuthorizeResult
+import com.tencent.devops.repository.service.github.GithubOAuthService
 import com.tencent.devops.repository.service.github.GithubTokenService
 import com.tencent.devops.repository.service.github.IGithubService
 import org.springframework.beans.factory.annotation.Autowired
@@ -37,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired
 @RestResource
 class UserGithubResourceImpl @Autowired constructor(
     private val githubService: IGithubService,
+    private val githubOAuthService: GithubOAuthService,
     private val githubTokenService: GithubTokenService
 ) : UserGithubResource {
     override fun getProject(userId: String, projectId: String, repoHashId: String?): Result<AuthorizeResult> {
@@ -46,5 +48,9 @@ class UserGithubResourceImpl @Autowired constructor(
     override fun deleteToken(userId: String): Result<Boolean> {
         githubTokenService.deleteAccessToken(userId)
         return Result(true)
+    }
+
+    override fun getGithubAppUrl(): Result<String> {
+        return Result(githubOAuthService.getGithubAppUrl())
     }
 }


### PR DESCRIPTION
github的使用需要在github上自行创建一个app, 可查看官方的文件https://docs.github.com/en/free-pro-team@latest/developers/apps/about-apps
## 以下是示例app，需要自行创建

```
需要将如下相应变量，填充到bkenv.properties 配置文件中， 再重新render_tpl生成配置文件
```

![image](https://user-images.githubusercontent.com/16686129/99356538-47abdf00-28e5-11eb-9c25-bc000ff719da.png)
![image](https://user-images.githubusercontent.com/16686129/99356232-cce2c400-28e4-11eb-88bf-44e60505abbd.png)