### PR TITLE
fix: 迁移github触发器相关接口 #3006

### DIFF
--- a/src/frontend/devops-pipeline/src/store/modules/soda/atom.js
+++ b/src/frontend/devops-pipeline/src/store/modules/soda/atom.js
@@ -96,7 +96,7 @@ const actions = {
     //     })
     // },
     getGithubAppUrl: async ({ commit }) => {
-        return request.get(`process/api/user/github/githubAppUrl`).then(response => {
+        return request.get(`repository/api/user/github/githubAppUrl`).then(response => {
             return response.data
         })
     },


### PR DESCRIPTION
fix: 迁移github触发器相关接口 #3006