### PR TITLE
feat：流水线重试startup,shutdown 构建次数标识，区分唯一构建记录 #3001

### DIFF
--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/mq/PipelineAgentShutdownEvent.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/mq/PipelineAgentShutdownEvent.kt
@@ -40,6 +40,7 @@ data class PipelineAgentShutdownEvent(
     val buildId: String,
     val vmSeqId: String?,
     val buildResult: Boolean,
+    val executeCount: Int?,
     override var actionType: ActionType = ActionType.REFRESH,
     override var delayMills: Int = 0,
     override var routeKeySuffix: String? = null

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/mq/PipelineBuildLessShutdownDispatchEvent.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/mq/PipelineBuildLessShutdownDispatchEvent.kt
@@ -40,6 +40,7 @@ data class PipelineBuildLessShutdownDispatchEvent(
     val buildId: String,
     val vmSeqId: String?,
     val buildResult: Boolean,
+    val executeCount: Int?,
     override var actionType: ActionType = ActionType.REFRESH,
     override var delayMills: Int = 0
 ) : IPipelineEvent(actionType, source, projectId, pipelineId, userId, delayMills)

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchBuildLessDockerShutdownTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchBuildLessDockerShutdownTaskAtom.kt
@@ -77,7 +77,8 @@ class DispatchBuildLessDockerShutdownTaskAtom @Autowired constructor(
                 userId = task.starter,
                 buildId = buildId,
                 vmSeqId = vmSeqId,
-                buildResult = true
+                buildResult = true,
+                executeCount = task.executeCount
             )
         )
         // 同步Job执行状态
@@ -111,7 +112,8 @@ class DispatchBuildLessDockerShutdownTaskAtom @Autowired constructor(
                         userId = task.starter,
                         buildId = task.buildId,
                         vmSeqId = task.containerId,
-                        buildResult = true
+                        buildResult = true,
+                        executeCount = task.executeCount
                     )
                 )
                 defaultFailAtomResponse
@@ -138,7 +140,8 @@ class DispatchBuildLessDockerShutdownTaskAtom @Autowired constructor(
             container: Container,
             containerSeq: Int,
             taskSeq: Int,
-            userId: String
+            userId: String,
+            executeCount: Int
         ): List<PipelineBuildTask> {
 
             val list: MutableList<PipelineBuildTask> = mutableListOf()
@@ -164,7 +167,7 @@ class DispatchBuildLessDockerShutdownTaskAtom @Autowired constructor(
                     taskAtom = "",
                     status = BuildStatus.QUEUE,
                     taskParams = mutableMapOf(),
-                    executeCount = 1,
+                    executeCount = executeCount,
                     starter = userId,
                     approver = null,
                     subBuildId = null,
@@ -193,7 +196,7 @@ class DispatchBuildLessDockerShutdownTaskAtom @Autowired constructor(
                     taskAtom = AtomUtils.parseAtomBeanName(DispatchBuildLessDockerShutdownTaskAtom::class.java),
                     status = BuildStatus.QUEUE,
                     taskParams = taskParams,
-                    executeCount = 1,
+                    executeCount = executeCount,
                     starter = userId,
                     approver = null,
                     subBuildId = null,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchBuildLessDockerStartupTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchBuildLessDockerStartupTaskAtom.kt
@@ -220,7 +220,8 @@ class DispatchBuildLessDockerStartupTaskAtom @Autowired constructor(
                         userId = task.starter,
                         buildId = task.buildId,
                         vmSeqId = task.containerId,
-                        buildResult = true
+                        buildResult = true,
+                        executeCount = task.executeCount
                     )
                 )
                 defaultFailAtomResponse
@@ -262,7 +263,8 @@ class DispatchBuildLessDockerStartupTaskAtom @Autowired constructor(
             container: Container,
             containerSeq: Int,
             taskSeq: Int,
-            userId: String
+            userId: String,
+            executeCount: Int
         ): PipelineBuildTask {
 
             // 防止
@@ -284,7 +286,7 @@ class DispatchBuildLessDockerStartupTaskAtom @Autowired constructor(
                 taskAtom = taskAtom,
                 status = BuildStatus.QUEUE,
                 taskParams = taskParams,
-                executeCount = 1,
+                executeCount = executeCount,
                 starter = userId,
                 approver = null,
                 subBuildId = null,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMShutdownTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMShutdownTaskAtom.kt
@@ -81,7 +81,8 @@ class DispatchVMShutdownTaskAtom @Autowired constructor(
                 buildId = buildId,
                 vmSeqId = vmSeqId,
                 buildResult = true,
-                routeKeySuffix = param.dispatchType?.routeKeySuffix?.routeKeySuffix
+                routeKeySuffix = param.dispatchType?.routeKeySuffix?.routeKeySuffix,
+                executeCount = task.executeCount
             )
         )
         // 同步Job执行状态
@@ -116,7 +117,8 @@ class DispatchVMShutdownTaskAtom @Autowired constructor(
                         buildId = task.buildId,
                         vmSeqId = task.containerId,
                         buildResult = true,
-                        routeKeySuffix = param.dispatchType?.routeKeySuffix?.routeKeySuffix
+                        routeKeySuffix = param.dispatchType?.routeKeySuffix?.routeKeySuffix,
+                        executeCount = task.executeCount
                     )
                 )
                 defaultFailAtomResponse
@@ -143,7 +145,8 @@ class DispatchVMShutdownTaskAtom @Autowired constructor(
             container: Container,
             containerSeq: Int,
             taskSeq: Int,
-            userId: String
+            userId: String,
+            executeCount: Int
         ): List<PipelineBuildTask> {
 
             val list: MutableList<PipelineBuildTask> = mutableListOf()
@@ -170,7 +173,7 @@ class DispatchVMShutdownTaskAtom @Autowired constructor(
                     taskAtom = "",
                     status = BuildStatus.QUEUE,
                     taskParams = mutableMapOf(),
-                    executeCount = 1,
+                    executeCount = executeCount,
                     starter = userId,
                     approver = null,
                     subBuildId = null,
@@ -200,7 +203,7 @@ class DispatchVMShutdownTaskAtom @Autowired constructor(
                     taskAtom = taskAtom,
                     status = BuildStatus.QUEUE,
                     taskParams = taskParams,
-                    executeCount = 1,
+                    executeCount = executeCount,
                     starter = userId,
                     approver = null,
                     subBuildId = null,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMStartupTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMStartupTaskAtom.kt
@@ -389,7 +389,8 @@ class DispatchVMStartupTaskAtom @Autowired constructor(
                         buildId = task.buildId,
                         vmSeqId = task.containerId,
                         buildResult = true,
-                        routeKeySuffix = param.dispatchType?.routeKeySuffix?.routeKeySuffix
+                        routeKeySuffix = param.dispatchType?.routeKeySuffix?.routeKeySuffix,
+                        executeCount = task.executeCount
                     )
                 )
                 defaultFailAtomResponse
@@ -426,7 +427,8 @@ class DispatchVMStartupTaskAtom @Autowired constructor(
             container: Container,
             containerSeq: Int,
             taskSeq: Int,
-            userId: String
+            userId: String,
+            executeCount: Int
         ): PipelineBuildTask {
 
             val taskParams = container.genTaskParams()
@@ -450,7 +452,7 @@ class DispatchVMStartupTaskAtom @Autowired constructor(
                 taskAtom = taskAtom,
                 status = BuildStatus.QUEUE,
                 taskParams = taskParams,
-                executeCount = 1,
+                executeCount = executeCount,
                 starter = userId,
                 approver = null,
                 subBuildId = null,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -1247,7 +1247,8 @@ class PipelineRuntimeService @Autowired constructor(
                         container = container,
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
-                        userId = userId
+                        userId = userId,
+                        executeCount = retryCount
                     )
                 )
                 buildTaskList.addAll(
@@ -1259,7 +1260,8 @@ class PipelineRuntimeService @Autowired constructor(
                         container = container,
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
-                        userId = userId
+                        userId = userId,
+                        executeCount = retryCount
                     )
                 )
             } else {
@@ -1272,7 +1274,8 @@ class PipelineRuntimeService @Autowired constructor(
                         container = container,
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
-                        userId = userId
+                        userId = userId,
+                        executeCount = retryCount
                     )
                 )
                 buildTaskList.addAll(
@@ -1284,7 +1287,8 @@ class PipelineRuntimeService @Autowired constructor(
                         container = container,
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
-                        userId = userId
+                        userId = userId,
+                        executeCount = retryCount
                     )
                 )
             }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -1235,6 +1235,8 @@ class PipelineRuntimeService @Autowired constructor(
             return
         }
 
+        val executeCount = if (retryCount > 0) { retryCount } else { 1 }
+
         if (lastTimeBuildTaskRecords.isEmpty()) {
             // 是否有原子市场的原子，则需要启动docker来运行
             if (container is NormalContainer) {
@@ -1248,7 +1250,7 @@ class PipelineRuntimeService @Autowired constructor(
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
                         userId = userId,
-                        executeCount = retryCount
+                        executeCount = executeCount
                     )
                 )
                 buildTaskList.addAll(
@@ -1261,7 +1263,7 @@ class PipelineRuntimeService @Autowired constructor(
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
                         userId = userId,
-                        executeCount = retryCount
+                        executeCount = executeCount
                     )
                 )
             } else {
@@ -1275,7 +1277,7 @@ class PipelineRuntimeService @Autowired constructor(
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
                         userId = userId,
-                        executeCount = retryCount
+                        executeCount = executeCount
                     )
                 )
                 buildTaskList.addAll(
@@ -1288,7 +1290,7 @@ class PipelineRuntimeService @Autowired constructor(
                         containerSeq = containerSeq,
                         taskSeq = startVMTaskSeq,
                         userId = userId,
-                        executeCount = retryCount
+                        executeCount = executeCount
                     )
                 )
             }


### PR DESCRIPTION
startup, shutdown 下发executeCount，供构建机区分同一buildId不同executeCount