### PR TITLE
bug: 构建机心跳超时，当没有任务在执行时，流水线状态应该为失败 #3155

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
@@ -391,7 +391,7 @@ class ContainerControl @Autowired constructor(
                 BuildStatus.isReadyToRun(finallyTasks[1].status) -> {
                     // 先将排队状态下的Hold点移出待执行状态，置为未执行。 对于插件执行失败的(非构建机启动失败），构建机已经将Hold点置为完成，所以不能再重置为未执行
                     if (BuildStatus.isReadyToRun(finallyTasks[0].status)) {
-                        pipelineRuntimeService.updateTaskStatus(buildId = buildId, taskId = finallyTasks[0].taskId, userId = userId, buildStatus = BuildStatus.UNEXEC)
+                        pipelineRuntimeService.updateTaskStatus(buildId = buildId, taskId = finallyTasks[0].taskId, userId = userId, buildStatus = BuildStatus.FAILED)
                     }
                     return finallyTasks[1] to ActionType.START // 再拿停止构建机
                 }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/ContainerControl.kt
@@ -389,7 +389,7 @@ class ContainerControl @Autowired constructor(
                 // 如果是非构建机启动失败或者关闭操作的，先拿结束点Hold拦截点让构建机来认领结束，否则都是直接关闭构建机
                 !startVMFail && !ActionType.isEnd(actionType) && BuildStatus.isReadyToRun(finallyTasks[0].status) -> return finallyTasks[0] to ActionType.START
                 BuildStatus.isReadyToRun(finallyTasks[1].status) -> {
-                    // 先将排队状态下的Hold点移出待执行状态，置为未执行。 对于插件执行失败的(非构建机启动失败），构建机已经将Hold点置为完成，所以不能再重置为未执行
+                    // #3155 当构建机启动失败或者心跳超时,先将排队状态下的Hold点移出待执行状态，直接置为失败。
                     if (BuildStatus.isReadyToRun(finallyTasks[0].status)) {
                         pipelineRuntimeService.updateTaskStatus(buildId = buildId, taskId = finallyTasks[0].taskId, userId = userId, buildStatus = BuildStatus.FAILED)
                     }


### PR DESCRIPTION
#3155
