### PR TITLE
bug: 日志模块索引名计算的日期模板错误 #3379

### DIFF
--- a/src/backend/ci/core/log/biz-log/src/main/kotlin/com/tencent/devops/log/util/IndexNameUtils.kt
+++ b/src/backend/ci/core/log/biz-log/src/main/kotlin/com/tencent/devops/log/util/IndexNameUtils.kt
@@ -42,5 +42,5 @@ object IndexNameUtils {
     }
 
     const val LOG_INDEX_PREFIX = "log-"
-    private const val LOG_INDEX_DATE_FORMAT = "YYYY-MM-dd"
+    private const val LOG_INDEX_DATE_FORMAT = "yyyy-MM-dd"
 }


### PR DESCRIPTION
更改日期计算模板，避免按YYYY时年末最后一周跨周时算入下一年 #3379 