### PR TITLE
bug:1.2开源版本插件首先上架一个版本下架后再上架一个新版本首页查询不到 #3403

### DIFF
--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/AtomReleaseServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/AtomReleaseServiceImpl.kt
@@ -854,7 +854,8 @@ abstract class AtomReleaseServiceImpl @Autowired constructor() : AtomReleaseServ
         if (!checkResult) {
             return MessageCodeUtil.generateResponseDataObject(code)
         }
-        if (isNormalUpgrade) {
+        val releaseFlag = atomStatus == AtomStatusEnum.RELEASED.status.toByte()
+        if (releaseFlag) {
             // 更新质量红线信息
             atomQualityService.updateQualityInApprove(atomRecord.atomCode, atomStatus)
             val creator = atomRecord.creator


### PR DESCRIPTION
bug:1.2开源版本插件首先上架一个版本下架后再上架一个新版本首页查询不到 #3403
#3403