### PR TITLE
bug: 流水线暂停后，选择操作为停止，流水线的取消用户为空的问题fix #3280

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
@@ -171,9 +171,11 @@ class PipelineTaskPauseListener @Autowired constructor(
             taskId = taskId
         )
 
+        buildDetailService.updateBuildCancelUser(buildId, userId)
+
         buildLogPrinter.addYellowLine(
             buildId = buildId,
-            message = "[$taskName] processed . user:$userId, action: terminate",
+            message = "[$taskName] processed . user : $userId, action: terminate",
             tag = taskId,
             jobId = containerId,
             executeCount = 1

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
@@ -136,7 +136,7 @@ class PipelineTaskPauseListener @Autowired constructor(
         )
         buildLogPrinter.addYellowLine(
             buildId = buildId,
-            message = "[$taskName] processed. user:$userId, action: continue",
+            message = "[$taskName] processed. user: $userId, action: continue",
             tag = taskId,
             jobId = containerId,
             executeCount = 1
@@ -175,7 +175,7 @@ class PipelineTaskPauseListener @Autowired constructor(
 
         buildLogPrinter.addYellowLine(
             buildId = buildId,
-            message = "[$taskName] processed . user : $userId, action: terminate",
+            message = "[$taskName] processed. user: $userId, action: terminate",
             tag = taskId,
             jobId = containerId,
             executeCount = 1

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineTaskService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineTaskService.kt
@@ -171,7 +171,7 @@ class PipelineTaskService @Autowired constructor(
         logger.info("pause atom, buildId[$buildId], taskId[$taskId] , additionalOptions[${taskRecord!!.additionalOptions}]")
         buildLogPrinter.addYellowLine(
             buildId = buildId,
-            message = "[${taskRecord.taskName}] pause，waiting ...",
+            message = "[${taskRecord.taskName}] pause, waiting ...",
             tag = taskRecord.taskId,
             jobId = taskRecord.containerId,
             executeCount = 1


### PR DESCRIPTION
暂停取消添加取消人信息 #3280 