### PR TITLE
refractor: 重构流水线默认创建的设置选项 #3311

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/dao/PipelineSettingDao.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/dao/PipelineSettingDao.kt
@@ -53,7 +53,7 @@ class PipelineSettingDao {
         pipelineId: String,
         pipelineName: String,
         isTemplate: Boolean = false,
-        successNotifyTypes: String = "${NotifyType.EMAIL.name},${NotifyType.RTX.name}",
+        successNotifyTypes: String = "",
         failNotifyTypes: String = "${NotifyType.EMAIL.name},${NotifyType.RTX.name}",
         maxPipelineResNum: Int? = PIPELINE_RES_NUM_MIN
     ): Int {

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRepositoryService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRepositoryService.kt
@@ -83,7 +83,6 @@ import org.joda.time.LocalDateTime
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.util.concurrent.atomic.AtomicInteger
 import javax.ws.rs.core.Response

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRepositoryService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRepositoryService.kt
@@ -112,9 +112,6 @@ class PipelineRepositoryService constructor(
     private val templatePipelineDao: TemplatePipelineDao
 ) {
 
-    @Value("\${notify.silent.channel:AM,CODECC,CODECC_EE,GONGFENGSCAN}")
-    private val notifySilentChannels: String = ""
-
     fun deployPipeline(
         model: Model,
         projectId: String,
@@ -315,9 +312,11 @@ class PipelineRepositoryService constructor(
                     Pair(RepositoryConfig(e.repositoryHashId, e.repositoryName, e.repositoryType ?: RepositoryType.ID), eventType)
                 }
                 is CodeGitlabWebHookTriggerElement -> {
-                    Pair(RepositoryConfig(e.repositoryHashId, e.repositoryName, e.repositoryType ?: RepositoryType.ID), CodeEventType.PUSH) }
+                    Pair(RepositoryConfig(e.repositoryHashId, e.repositoryName, e.repositoryType ?: RepositoryType.ID), CodeEventType.PUSH)
+                }
                 is CodeGithubWebHookTriggerElement -> {
-                    Pair(RepositoryConfig(e.repositoryHashId, e.repositoryName, e.repositoryType ?: RepositoryType.ID), e.eventType) }
+                    Pair(RepositoryConfig(e.repositoryHashId, e.repositoryName, e.repositoryType ?: RepositoryType.ID), e.eventType)
+                }
                 is CodeTGitWebHookTriggerElement -> {
                     // CodeEventType.MERGE_REQUEST_ACCEPT 和 CodeEventType.MERGE_REQUEST等价处理
                     val eventType = if (e.data.input.eventType == CodeEventType.MERGE_REQUEST_ACCEPT) CodeEventType.MERGE_REQUEST else e.data.input.eventType
@@ -496,11 +495,15 @@ class PipelineRepositoryService constructor(
                 !model.instanceFromTemplate!!
             ) {
                 if (null == pipelineSettingDao.getSetting(transactionContext, pipelineId)) {
-                    var notifyTypes = "${NotifyType.EMAIL.name},${NotifyType.RTX.name}"
-                    if (channelCode.name in notifySilentChannels.split(",")) {
-                        // 研发商店创建的内置流水线默认不发送通知消息
-                        notifyTypes = ""
+                    // #3311
+                    // 蓝盾正常的BS渠道的默认没设置setting的，将发通知改成失败才发通知
+                    // 而其他渠道的默认没设置则什么通知都设置为不发
+                    var notifyTypes = if (channelCode == ChannelCode.BS) {
+                        "${NotifyType.EMAIL.name},${NotifyType.RTX.name}"
+                    } else {
+                        ""
                     }
+
                     // 渠道为工蜂或者开源扫描只需为流水线模型保留一个版本
                     val filterList = listOf(ChannelCode.GIT, ChannelCode.GONGFENGSCAN)
                     val maxPipelineResNum = if (channelCode in filterList) 1 else PIPELINE_RES_NUM_MIN
@@ -509,7 +512,6 @@ class PipelineRepositoryService constructor(
                         projectId = projectId,
                         pipelineId = pipelineId,
                         pipelineName = model.name,
-                        successNotifyTypes = notifyTypes,
                         failNotifyTypes = notifyTypes,
                         maxPipelineResNum = maxPipelineResNum
                     )


### PR DESCRIPTION
1. 只有Channel为BS的流水线才初始化配置通知渠道。
2. BS默认只有失败发送， 成功不发送