### PR TITLE
perf: 内置插件和心跳超时的执行错误信息优化 #2993 不能直接通过output判断 回退

### DIFF
--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/market/MarketAtomTask.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/market/MarketAtomTask.kt
@@ -434,11 +434,6 @@ open class MarketAtomTask : ITask() {
         val success: Boolean
         if (atomResult == null) {
             LoggerService.addYellowLine("No output")
-            throw TaskExecuteException(
-                errorMsg = "[Task load error] ${buildTask.elementName} could not be load",
-                errorType = ErrorType.SYSTEM,
-                errorCode = ErrorCode.SYSTEM_WORKER_LOADING_ERROR
-            )
         } else {
             if (atomResult.status == "success") {
                 success = true


### PR DESCRIPTION
不能直接通过output判断 回退 #2993