### PR TITLE
bug: 分级管理员超时越界问题 #3673

### DIFF
--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/ManagerUserService.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/ManagerUserService.kt
@@ -106,7 +106,6 @@ class ManagerUserService @Autowired constructor(
     }
 
     fun createManagerUser(userId: String, managerUser: ManagerUserDTO): Int {
-        logger.info("createManagerUser | $userId | $managerUser")
         val managerInfo = ManagerUserEntity(
             createUser = userId,
             managerId = managerUser.managerId,
@@ -114,6 +113,7 @@ class ManagerUserService @Autowired constructor(
             timeoutTime = System.currentTimeMillis() + (DateTimeUtil.minuteToSecond(managerUser.timeout!!).toLong() * 1000),
             userId = managerUser.userId
         )
+        logger.info("createManagerUser | $managerInfo")
 
         val record = managerUserDao.get(dslContext, managerInfo.managerId, managerInfo.userId)
 

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/ManagerUserService.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/ManagerUserService.kt
@@ -111,7 +111,7 @@ class ManagerUserService @Autowired constructor(
             createUser = userId,
             managerId = managerUser.managerId,
             startTime = System.currentTimeMillis(),
-            timeoutTime = System.currentTimeMillis() + (DateTimeUtil.minuteToSecond(managerUser.timeout!!) * 1000),
+            timeoutTime = System.currentTimeMillis() + (DateTimeUtil.minuteToSecond(managerUser.timeout!!).toLong() * 1000),
             userId = managerUser.userId
         )
 

--- a/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/DateTimeUtilTest.kt
+++ b/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/DateTimeUtilTest.kt
@@ -122,4 +122,21 @@ class DateTimeUtilTest {
         val dateStr = DateTimeUtil.toDateTime(date)
         println(dateStr)
     }
+
+    @Test
+    fun outOfBoundsInt() {
+        val year = 525600
+        val lastTime = (DateTimeUtil.minuteToSecond(year) * 1000)
+        val maxInt = Int.MAX_VALUE
+        Assert.assertFalse(lastTime - maxInt > 0)
+    }
+
+    @Test
+    fun outOfBoundsLong() {
+        val year = 525600
+        val lastTime = (DateTimeUtil.minuteToSecond(year).toLong() * 1000)
+        val maxInt = Int.MAX_VALUE
+        Assert.assertTrue(lastTime - maxInt > 0)
+    }
+
 }

--- a/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/DateTimeUtilTest.kt
+++ b/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/DateTimeUtilTest.kt
@@ -138,5 +138,4 @@ class DateTimeUtilTest {
         val maxInt = Int.MAX_VALUE
         Assert.assertTrue(lastTime - maxInt > 0)
     }
-
 }


### PR DESCRIPTION
调整超时时间为long，防止int越界导致时间错乱