### PR TITLE
feat: 引擎核心代码拆分出biz-process业务模块 #3400

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/utils/PipelineUtils.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/utils/PipelineUtils.kt
@@ -45,7 +45,7 @@ object PipelineUtils {
 
     private val logger = LoggerFactory.getLogger(PipelineUtils::class.java)
 
-    private const val ENGLISH_NAME_PATTERN = "[A-Za-z_][A-Za-z_0-9]+"
+    private const val ENGLISH_NAME_PATTERN = "[A-Za-z_][A-Za-z_0-9]*"
     private const val MAX_DESC_LENGTH = 100
     private const val MAX_NAME_LENGTH = 64
 


### PR DESCRIPTION
流水线的启动参数命名支持单个字符