### PR TITLE
refactor:开源版，研发商店组件logo、文档链接中域名在数据库硬编码，导致用户切换域名后无法查看图片 #3780

### DIFF
--- a/src/backend/ci/core/store/biz-store-sample/src/main/kotlin/com/tencent/devops/store/service/common/impl/SampleStoreLogoServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store-sample/src/main/kotlin/com/tencent/devops/store/service/common/impl/SampleStoreLogoServiceImpl.kt
@@ -30,6 +30,7 @@ import com.tencent.devops.artifactory.api.service.ServiceFileResource
 import com.tencent.devops.artifactory.pojo.enums.FileChannelTypeEnum
 import com.tencent.devops.common.api.pojo.Result
 import com.tencent.devops.common.service.utils.CommonUtils
+import com.tencent.devops.store.utils.StoreUtils
 import org.springframework.stereotype.Service
 import java.io.File
 

--- a/src/backend/ci/core/store/biz-store-sample/src/main/kotlin/com/tencent/devops/store/service/common/impl/SampleStoreLogoServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store-sample/src/main/kotlin/com/tencent/devops/store/service/common/impl/SampleStoreLogoServiceImpl.kt
@@ -38,6 +38,13 @@ class SampleStoreLogoServiceImpl : StoreLogoServiceImpl() {
 
     override fun uploadStoreLogo(userId: String, file: File): Result<String?> {
         val serviceUrlPrefix = client.getServiceUrl(ServiceFileResource::class)
-        return CommonUtils.serviceUploadFile(userId, serviceUrlPrefix, file, FileChannelTypeEnum.WEB_SHOW.name)
+        val logoUrl = CommonUtils.serviceUploadFile(
+            userId = userId,
+            serviceUrlPrefix = serviceUrlPrefix,
+            file = file,
+            fileChannelType = FileChannelTypeEnum.WEB_SHOW.name
+        ).data
+        // 开源版如果logoUrl的域名和ci域名一样，则logoUrl无需带上域名，防止域名变更影响图片显示（logoUrl会存db）
+        return Result(if (logoUrl != null) StoreUtils.removeUrlHost(logoUrl) else logoUrl)
     }
 }

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/AtomReleaseServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/AtomReleaseServiceImpl.kt
@@ -144,10 +144,8 @@ abstract class AtomReleaseServiceImpl @Autowired constructor() : AtomReleaseServ
     protected lateinit var atomDetailBaseUrl: String
 
     private fun validateAddMarketAtomReq(
-        userId: String,
         marketAtomCreateRequest: MarketAtomCreateRequest
     ): Result<Boolean> {
-        logger.info("the validateAddMarketAtomReq userId is :$userId,marketAtomCreateRequest is :$marketAtomCreateRequest")
         val atomCode = marketAtomCreateRequest.atomCode
         // 判断插件代码是否存在
         val codeCount = atomDao.countByCode(dslContext, atomCode)
@@ -179,7 +177,7 @@ abstract class AtomReleaseServiceImpl @Autowired constructor() : AtomReleaseServ
     ): Result<Boolean> {
         logger.info("addMarketAtom userId is :$userId,marketAtomCreateRequest is :$marketAtomCreateRequest")
         val atomCode = marketAtomCreateRequest.atomCode
-        val validateResult = validateAddMarketAtomReq(userId, marketAtomCreateRequest)
+        val validateResult = validateAddMarketAtomReq(marketAtomCreateRequest)
         logger.info("the validateResult is :$validateResult")
         if (validateResult.isNotOk()) {
             return validateResult

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/utils/StoreUtils.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/utils/StoreUtils.kt
@@ -1,0 +1,62 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.devops.store.utils
+
+import com.tencent.devops.common.service.config.CommonConfig
+import com.tencent.devops.common.service.utils.HomeHostUtil
+import com.tencent.devops.common.service.utils.SpringContextUtil
+
+object StoreUtils {
+
+    /**
+     * 移除链接地址中的域名信息
+     * @param url 链接地址
+     */
+    fun removeUrlHost(url: String): String {
+        val host = getHost()
+        return url.removePrefix(host)
+    }
+
+    /**
+     * 为链接地址添加域名信息
+     * @param url 链接地址
+     */
+    fun addUrlHost(url: String): String {
+        val host = getHost()
+        return if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            if (url.startsWith("/")) "$host$url" else "$host/$url"
+        } else {
+            url
+        }
+    }
+
+    private fun getHost(): String {
+        val commonConfig: CommonConfig = SpringContextUtil.getBean(CommonConfig::class.java)
+        return HomeHostUtil.getHost(commonConfig.devopsHostGateway!!)
+    }
+}

--- a/support-files/templates/#etc#ci#application-store.yml
+++ b/support-files/templates/#etc#ci#application-store.yml
@@ -12,12 +12,12 @@ server:
 store:
   commentNotifyAdmin: admin
   profileUrlPrefix: __BK_CI_STORE_USER_AVATARS_URL__
-  atomDetailBaseUrl: __BK_CI_PUBLIC_URL__/console/store/atomStore/detail/atom/
-  templateDetailBaseUrl: __BK_CI_PUBLIC_URL__/console/store/atomStore/detail/template/
+  atomDetailBaseUrl: /console/store/atomStore/detail/atom/
+  templateDetailBaseUrl: /console/store/atomStore/detail/template/
   artifactoryServiceUrlPrefix: __BK_CI_PUBLIC_URL__/ms/artifactory/api
-  ideAtomDetailBaseUrl: __BK_CI_PUBLIC_URL__/console/store/atomStore/detail/ide/
-  imageDetailBaseUrl: __BK_CI_PUBLIC_URL__/console/store/atomStore/detail/image/
-  serviceDetailBaseUrl: __BK_CI_PUBLIC_URL__/console/store/atomStore/detail/service/
+  ideAtomDetailBaseUrl: /console/store/atomStore/detail/ide/
+  imageDetailBaseUrl: /console/store/atomStore/detail/image/
+  serviceDetailBaseUrl: /console/store/atomStore/detail/service/
   baseImageDocsLink: /console/store/atomStore/detail/image/
   imageAdminUsers: admin
   buildResultBaseUrl: __BK_CI_PUBLIC_URL__/console/pipeline


### PR DESCRIPTION
refactor:开源版，研发商店组件logo、文档链接中域名在数据库硬编码，导致用户切换域名后无法查看图片 #3780
#3780