### PR TITLE
人工审核审核时，变量名称hover展示对应的变量描述

### DIFF
--- a/src/frontend/devops-pipeline/src/components/Stages/CheckAtomDialog.vue
+++ b/src/frontend/devops-pipeline/src/components/Stages/CheckAtomDialog.vue
@@ -36,7 +36,7 @@
                             <vuex-input
                                 :data-vv-scope="`param-${paramIndex}`"
                                 :disabled="true"
-                                v-bk-tooltips="{ content: param.desc, placements: ['bottom'] }"
+                                :desc-tooltips="param.desc"
                                 :handle-change="(name, value) => handleParamChange(name, value, paramIndex)"
                                 v-validate.initial="`required|unique:${data.params.map(p => p.key).join(&quot;,&quot;)}|max: 50|${snonVarRule}`"
                                 name="key"

--- a/src/frontend/devops-pipeline/src/components/atomFormField/atomFieldMixin.js
+++ b/src/frontend/devops-pipeline/src/components/atomFormField/atomFieldMixin.js
@@ -82,7 +82,7 @@ const atomFieldMixin = {
     },
     mounted () {
         const ele = document.querySelector('.atom-form-box')
-        if (this.descTooltips && this.disabled) {
+        if (this.descTooltips.length && this.disabled) {
             this.title = this.descTooltips
             this.readOnly = true
         } else if ((ele && ele.classList.contains('readonly')) || this.disabled) {

--- a/src/frontend/devops-pipeline/src/components/atomFormField/atomFieldMixin.js
+++ b/src/frontend/devops-pipeline/src/components/atomFormField/atomFieldMixin.js
@@ -63,6 +63,10 @@ const atomFieldMixin = {
         },
         clickUnfold: {
             type: Boolean
+        },
+        descTooltips: {
+            type: String,
+            default: ''
         }
     },
     data () {
@@ -78,7 +82,10 @@ const atomFieldMixin = {
     },
     mounted () {
         const ele = document.querySelector('.atom-form-box')
-        if ((ele && ele.classList.contains('readonly')) || this.disabled) {
+        if (this.descTooltips && this.disabled) {
+            this.title = this.descTooltips
+            this.readOnly = true
+        } else if ((ele && ele.classList.contains('readonly')) || this.disabled) {
             this.title = this.value
             this.readOnly = true
         }


### PR DESCRIPTION
fix: 人工审核审核时，变量名称hover展示对应的变量描述 issue #3845