### PR TITLE
feat:请求服务支持consul tags路由

### DIFF
--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ClientAutoConfiguration.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ClientAutoConfiguration.kt
@@ -28,8 +28,10 @@
 package com.tencent.devops.common.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.tencent.devops.common.client.consul.ConsulFilter
 import com.tencent.devops.common.service.ServiceAutoConfiguration
 import com.tencent.devops.common.service.config.CommonConfig
+import com.tencent.devops.common.service.trace.TraceFilter
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.AutoConfigureOrder
@@ -65,4 +67,7 @@ class ClientAutoConfiguration {
         objectMapper: ObjectMapper,
         @Autowired(required = false) consulDiscoveryClient: ConsulDiscoveryClient?
     ) = Client(consulDiscoveryClient, clientErrorDecoder, commonConfig, objectMapper)
+
+    @Bean
+    fun consulFilter() = ConsulFilter()
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ClientAutoConfiguration.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ClientAutoConfiguration.kt
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.tencent.devops.common.client.consul.ConsulFilter
 import com.tencent.devops.common.service.ServiceAutoConfiguration
 import com.tencent.devops.common.service.config.CommonConfig
-import com.tencent.devops.common.service.trace.TraceFilter
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.AutoConfigureOrder

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulConstants.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulConstants.kt
@@ -23,20 +23,14 @@
  * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
  */
 
-apply plugin: "maven"
+package com.tencent.devops.common.client.consul
 
-dependencies {
-    compile project(":core:common:common-api")
-    compile project(":core:common:common-service")
-    compile project(":core:common:common-security")
-    compile project(":core:common:common-client")
-    compile "org.springframework.boot:spring-boot-starter-jersey"
-    compile "org.springframework.boot:spring-boot-starter-undertow"
-    compile "org.springframework.boot:spring-boot-starter-web"
-    compile "io.swagger:swagger-jersey2-jaxrs"
-    compile "com.github.ulisesbocchio:jasypt-spring-boot-starter"
-    compile "org.springframework.boot:spring-boot-starter-amqp"
-    compile('org.springframework.cloud:spring-cloud-starter-config')
+object ConsulConstants {
+
+    const val PROJECT_TAG_REDIS_KEY = "project:setting:tag:v2"
+
+    const val HEAD_CONSUL_TAG = "X-HEAD-CONSUL-TAG"
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulContent.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulContent.kt
@@ -23,20 +23,19 @@
  * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
  */
 
-apply plugin: "maven"
+package com.tencent.devops.common.client.consul
 
-dependencies {
-    compile project(":core:common:common-api")
-    compile project(":core:common:common-service")
-    compile project(":core:common:common-security")
-    compile project(":core:common:common-client")
-    compile "org.springframework.boot:spring-boot-starter-jersey"
-    compile "org.springframework.boot:spring-boot-starter-undertow"
-    compile "org.springframework.boot:spring-boot-starter-web"
-    compile "io.swagger:swagger-jersey2-jaxrs"
-    compile "com.github.ulisesbocchio:jasypt-spring-boot-starter"
-    compile "org.springframework.boot:spring-boot-starter-amqp"
-    compile('org.springframework.cloud:spring-cloud-starter-config')
+object ConsulContent {
+    private val consulContent = ThreadLocal<String>()
+
+    fun getConsulContent(): String? {
+        return consulContent.get()
+    }
+
+    fun setConsulContent(consulTag: String) {
+        consulContent.set(consulTag)
+    }
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
@@ -49,6 +49,7 @@ class ConsulFilter : Filter {
         if (consulTag != null) {
             ConsulContent.setConsulContent(consulTag)
         }
+        chain?.doFilter(request, response)
     }
 
     override fun destroy() {

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
@@ -41,7 +41,6 @@ import javax.servlet.http.HttpServletRequest
 class ConsulFilter : Filter {
 
     override fun init(p0: FilterConfig?) {
-        TODO("Not yet implemented")
     }
 
     override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
@@ -53,6 +52,5 @@ class ConsulFilter : Filter {
     }
 
     override fun destroy() {
-        TODO("Not yet implemented")
     }
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
@@ -23,20 +23,36 @@
  * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
  */
 
-apply plugin: "maven"
+package com.tencent.devops.common.client.consul
 
-dependencies {
-    compile project(":core:common:common-api")
-    compile project(":core:common:common-service")
-    compile project(":core:common:common-security")
-    compile project(":core:common:common-client")
-    compile "org.springframework.boot:spring-boot-starter-jersey"
-    compile "org.springframework.boot:spring-boot-starter-undertow"
-    compile "org.springframework.boot:spring-boot-starter-web"
-    compile "io.swagger:swagger-jersey2-jaxrs"
-    compile "com.github.ulisesbocchio:jasypt-spring-boot-starter"
-    compile "org.springframework.boot:spring-boot-starter-amqp"
-    compile('org.springframework.cloud:spring-cloud-starter-config')
+import com.tencent.devops.common.service.trace.TraceTag
+import org.springframework.stereotype.Component
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+
+@Component
+class ConsulFilter : Filter {
+
+    override fun init(p0: FilterConfig?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
+        val httpServletRequest = request as HttpServletRequest
+        val consulTag = httpServletRequest?.getHeader(ConsulConstants.HEAD_CONSUL_TAG)
+        if (consulTag != null) {
+            ConsulContent.setConsulContent(consulTag)
+        }
+    }
+
+    override fun destroy() {
+        TODO("Not yet implemented")
+    }
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
@@ -40,6 +40,7 @@ import javax.servlet.http.HttpServletRequest
 class ConsulFilter : Filter {
 
     override fun init(p0: FilterConfig?) {
+        return
     }
 
     override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
@@ -52,5 +53,6 @@ class ConsulFilter : Filter {
     }
 
     override fun destroy() {
+        return
     }
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/consul/ConsulFilter.kt
@@ -28,7 +28,6 @@
 
 package com.tencent.devops.common.client.consul
 
-import com.tencent.devops.common.service.trace.TraceTag
 import org.springframework.stereotype.Component
 import javax.servlet.Filter
 import javax.servlet.FilterChain

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
@@ -32,6 +32,7 @@ import com.tencent.devops.common.api.exception.ClientException
 import com.tencent.devops.common.service.utils.MessageCodeUtil
 import feign.Request
 import feign.RequestTemplate
+import org.slf4j.LoggerFactory
 import org.springframework.cloud.client.ServiceInstance
 import org.springframework.cloud.consul.discovery.ConsulDiscoveryClient
 import java.util.concurrent.ConcurrentHashMap
@@ -60,6 +61,10 @@ class MicroServiceTarget<T> constructor(
         val matchTagInstances = ArrayList<ServiceInstance>()
 
         instances.forEach next@{ serviceInstance ->
+            if (serviceName == "project") {
+                logger.info("consul info: $serviceInstance, tags $tag")
+            }
+
             if (serviceInstance.metadata.isEmpty())
                 return@next
             if (serviceInstance.metadata.values.contains(tag)) {
@@ -99,4 +104,8 @@ class MicroServiceTarget<T> constructor(
     override fun name() = serviceName
 
     private fun ServiceInstance.url() = "${if (isSecure) "https" else "http"}://$host:$port/api"
+
+    companion object {
+        val logger = LoggerFactory.getLogger(MicroServiceTarget::class.java)
+    }
 }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
@@ -63,7 +63,7 @@ class MicroServiceTarget<T> constructor(
 
         // 若前文中有指定过consul tag则用指定的，否则用本地的consul tag
         val consulContentTag = ConsulContent.getConsulContent()
-        val useConsulTag = if (consulContentTag != null || !consulContentTag.isNullOrEmpty()) {
+        val useConsulTag = if (!consulContentTag.isNullOrEmpty()) {
             consulContentTag
         } else tag
 

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
@@ -29,6 +29,7 @@ package com.tencent.devops.common.client.ms
 
 import com.tencent.devops.common.api.constant.CommonMessageCode.ERROR_SERVICE_NO_FOUND
 import com.tencent.devops.common.api.exception.ClientException
+import com.tencent.devops.common.client.consul.ConsulContent
 import com.tencent.devops.common.service.utils.MessageCodeUtil
 import feign.Request
 import feign.RequestTemplate
@@ -60,6 +61,12 @@ class MicroServiceTarget<T> constructor(
 
         val matchTagInstances = ArrayList<ServiceInstance>()
 
+        // 若前文中有指定过consul tag则用指定的，否则用本地的consul tag
+        val consulContentTag = ConsulContent.getConsulContent()
+        val useConsulTag = if (consulContentTag != null || !consulContentTag.isNullOrEmpty()) {
+            consulContentTag
+        } else tag
+
         instances.forEach next@{ serviceInstance ->
             if (serviceName == "project") {
                 logger.info("consul info: $serviceInstance, tags $tag")
@@ -67,7 +74,8 @@ class MicroServiceTarget<T> constructor(
 
             if (serviceInstance.metadata.isEmpty())
                 return@next
-            if (serviceInstance.metadata.values.contains(tag)) {
+
+            if (serviceInstance.metadata.values.contains(useConsulTag)) {
                 // 已经用过的不选择
                 if (!usedInstance.contains(serviceInstance.url())) {
                     matchTagInstances.add(serviceInstance)
@@ -81,7 +89,7 @@ class MicroServiceTarget<T> constructor(
         }
 
         if (matchTagInstances.isEmpty()) {
-            throw ClientException(errorInfo.message ?: "找不到任何有效的[$serviceName]服务提供者")
+            throw ClientException(errorInfo.message ?: "找不到任何有效的[$serviceName]-[$useConsulTag]服务提供者")
         } else if (matchTagInstances.size > 1) {
             matchTagInstances.shuffle()
         }

--- a/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
+++ b/src/backend/ci/core/common/common-client/src/main/kotlin/com/tencent/devops/common/client/ms/MicroServiceTarget.kt
@@ -68,10 +68,6 @@ class MicroServiceTarget<T> constructor(
         } else tag
 
         instances.forEach next@{ serviceInstance ->
-            if (serviceName == "project") {
-                logger.info("consul info: $serviceInstance, tags $tag")
-            }
-
             if (serviceInstance.metadata.isEmpty())
                 return@next
 

--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/FeignConfiguration.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/FeignConfiguration.kt
@@ -28,6 +28,8 @@
 package com.tencent.devops.common.web
 
 import com.tencent.devops.common.api.auth.AUTH_HEADER_DEVOPS_JWT_TOKEN
+import com.tencent.devops.common.client.consul.ConsulConstants
+import com.tencent.devops.common.client.consul.ConsulContent
 import com.tencent.devops.common.security.jwt.JwtManager
 import com.tencent.devops.common.service.trace.TraceTag
 import feign.RequestInterceptor
@@ -77,6 +79,11 @@ class FeignConfiguration {
                 if (jwtManager.isSendEnable()) {
                     requestTemplate.header(AUTH_HEADER_DEVOPS_JWT_TOKEN, jwtManager.getToken() ?: "")
                 }
+            }
+
+            // 增加X-HEAD-CONSUL-TAG供下游服务获取相同的consul tag
+            if (ConsulContent.getConsulContent() != null) {
+                requestTemplate.header(ConsulConstants.HEAD_CONSUL_TAG, ConsulContent.getConsulContent())
             }
         }
     }

--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/FeignConfiguration.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/FeignConfiguration.kt
@@ -82,7 +82,7 @@ class FeignConfiguration {
             }
 
             // 增加X-HEAD-CONSUL-TAG供下游服务获取相同的consul tag
-            if (ConsulContent.getConsulContent() != null) {
+            if (!ConsulContent.getConsulContent().isNullOrEmpty()) {
                 requestTemplate.header(ConsulConstants.HEAD_CONSUL_TAG, ConsulContent.getConsulContent())
             }
         }

--- a/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/aspect/ApiAspect.kt
+++ b/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/aspect/ApiAspect.kt
@@ -27,6 +27,9 @@
 package com.tencent.devops.openapi.aspect
 
 import com.tencent.devops.common.api.exception.PermissionForbiddenException
+import com.tencent.devops.common.client.consul.ConsulConstants.PROJECT_TAG_REDIS_KEY
+import com.tencent.devops.common.client.consul.ConsulContent
+import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.openapi.filter.ApiFilter
 import com.tencent.devops.openapi.service.op.AppCodeService
 import com.tencent.devops.openapi.utils.ApiGatewayUtil
@@ -43,7 +46,8 @@ import org.springframework.stereotype.Component
 @Suppress("ALL")
 class ApiAspect(
     private val appCodeService: AppCodeService,
-    private val apiGatewayUtil: ApiGatewayUtil
+    private val apiGatewayUtil: ApiGatewayUtil,
+    private val redisOperation: RedisOperation
 ) {
 
     companion object {
@@ -104,6 +108,12 @@ class ApiAspect(
                 throw PermissionForbiddenException(
                     message = "Permission denied: apigwType[$apigwType],appCode[$appCode],ProjectId[$projectId]"
                 )
+            }
+
+            // openAPI 网关无法判别项目信息, 切面捕获project信息。 剩余一种URI内无${projectId}的情况,接口自行处理
+            val projectConsulTag = redisOperation.hget(PROJECT_TAG_REDIS_KEY, projectId)
+            if (projectConsulTag != null) {
+                ConsulContent.setConsulContent(projectConsulTag)
             }
         }
     }

--- a/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/aspect/ApiAspect.kt
+++ b/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/aspect/ApiAspect.kt
@@ -112,7 +112,7 @@ class ApiAspect(
 
             // openAPI 网关无法判别项目信息, 切面捕获project信息。 剩余一种URI内无${projectId}的情况,接口自行处理
             val projectConsulTag = redisOperation.hget(PROJECT_TAG_REDIS_KEY, projectId)
-            if (projectConsulTag != null) {
+            if (!projectConsulTag.isNullOrEmpty()) {
                 ConsulContent.setConsulContent(projectConsulTag)
             }
         }

--- a/support-files/sql/1001_ci_project_ddl_mysql.sql
+++ b/support-files/sql/1001_ci_project_ddl_mysql.sql
@@ -141,6 +141,7 @@ CREATE TABLE IF NOT EXISTS `T_PROJECT` (
   `enabled` bit(1) DEFAULT NULL,
   `CHANNEL` varchar(32) NOT NULL DEFAULT 'BS',
   `pipeline_limit` int(10) DEFAULT 500 COMMENT '流水线数量上限',
+  `router_tag` varchar(32) DEFAULT NULL COMMENT '网关路由tags',
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE KEY `project_name` (`project_name`) USING BTREE,
   UNIQUE KEY `project_id` (`project_id`) USING BTREE,

--- a/support-files/sql/2004_ci_project-update_v1.2_mysql.sql
+++ b/support-files/sql/2004_ci_project-update_v1.2_mysql.sql
@@ -21,6 +21,15 @@ BEGIN
             ADD INDEX `idx_username` (`username`);
     END IF;
 
+	IF NOT EXISTS(SELECT 1
+                      FROM information_schema.COLUMNS
+                      WHERE TABLE_SCHEMA = db
+                        AND TABLE_NAME = 'T_PROJECT'
+                        AND COLUMN_NAME = 'router_tag') THEN
+        ALTER TABLE T_PIPELINE_BUILD_HISTORY
+            ADD COLUMN `router_tag` VARCHAR(32);
+    END IF;
+
     COMMIT;
 END <CI_UBF>
 DELIMITER ;


### PR DESCRIPTION
1. 增强feign的路由策略。支持根据consul tag做路由。
2. openAPI添加根据projectID设置consul tag的埋点。
