### PR TITLE
修复流水线列表列宽拖拽后仍展示不全流水线名称

### DIFF
--- a/src/frontend/devops-pipeline/src/views/list/newlist.vue
+++ b/src/frontend/devops-pipeline/src/views/list/newlist.vue
@@ -1151,7 +1151,6 @@
             cursor: pointer;
         }
         .table-list-name {
-            max-width: 300px;
             padding-left: 30px;
         }
         .table-list-progress {


### PR DESCRIPTION
fix: 修复流水线列表列宽拖拽后仍展示不全流水线名称 issue #3972