### PR TITLE
bug: 转发到bkrepo的service路径不需要重写X-BKREPO-UID #4113

### DIFF
--- a/src/gateway/core/proxy.set.header.service.conf
+++ b/src/gateway/core/proxy.set.header.service.conf
@@ -1,9 +1,8 @@
-        proxy_set_header X-DEVOPS-UID $uid;
-		proxy_set_header X-BKREPO-UID $uid;
-		proxy_set_header X-DEVOPS-SID $uid;
-		proxy_set_header X-DEVOPS-SNAME $uid;
-		proxy_set_header X-SODA-UID $uid;
-		proxy_set_header X-SODA-SID $uid;
-		proxy_set_header X-SODA-SNAME $uid;
+proxy_set_header X-DEVOPS-UID $uid;
+proxy_set_header X-DEVOPS-SID $uid;
+proxy_set_header X-DEVOPS-SNAME $uid;
+proxy_set_header X-SODA-UID $uid;
+proxy_set_header X-SODA-SID $uid;
+proxy_set_header X-SODA-SNAME $uid;
 
-		include proxy.set.header.common.conf;
+include proxy.set.header.common.conf;


### PR DESCRIPTION
#4113 