### PR TITLE
bug:上下文jobs.使用jobId引用插件输出，而不是id和containerId #4380

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/PipelineContextService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/PipelineContextService.kt
@@ -342,7 +342,7 @@ class PipelineContextService@Autowired constructor(
     private fun getStepOutput(c: Container, e: Element, buildVar: Map<String, String>): Map<out String, String> {
         val outputMap = mutableMapOf<String, String>()
         buildVar.filterKeys { it.startsWith("steps.${e.id ?: ""}.outputs.") }.forEach { (t, u) ->
-            outputMap["jobs.${c.id}.$t"] = u
+            outputMap["jobs.${c.jobId ?: c.id ?: ""}.$t"] = u
         }
         return outputMap
     }


### PR DESCRIPTION
bug:上下文jobs.使用jobId引用插件输出，而不是id和containerId #4380