### PR TITLE
修复排队跳过时，最后一个Stage处于禁用时，会导致变成变成成功

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildStageDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildStageDao.kt
@@ -264,7 +264,7 @@ class PipelineBuildStageDao {
         with(T_PIPELINE_BUILD_STAGE) {
             val data = dslContext.selectFrom(this)
                 .where(BUILD_ID.eq(buildId)).and(STATUS.eq(status.ordinal))
-                .orderBy(SEQ.desc()).limit(1).fetchAny()
+                .orderBy(SEQ.asc()).limit(1).fetchAny()
             return convert(data)
         }
     }


### PR DESCRIPTION
修复排队跳过时，最后一个Stage处于禁用时，会导致变成变成成功