### PR TITLE
chore: 部署问题汇总202106 #4591

### DIFF
--- a/scripts/bkce-check-installconfig.sh
+++ b/scripts/bkce-check-installconfig.sh
@@ -123,6 +123,10 @@ then
   exit 1
 fi
 
+# docker冲突检查. 
+install_config_conflict "${BK_CI_AGENTLESS_IP_COMMA:-},${BK_CI_DOCKERHOST_IP_COMMA:-}" \
+  "ci(agentless)和ci(dockerhost)" "需要独占docker" \
+  "将ci(dockerhost)移到其他节点"
 # ci组件配置.
 install_config_exist "${BK_CI_GATEWAY_IP:-}" \
   "ci(gateway)" \


### PR DESCRIPTION
目前agentless和dockerhost不能在同一台, 检查并禁止.
chore: 部署问题汇总202106 #4591