### PR TITLE
feat: 变量支持二次替换 #4559

### DIFF
--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/EnvUtils.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/EnvUtils.kt
@@ -83,7 +83,7 @@ object EnvUtils {
             matcher.appendReplacement(buff, Matcher.quoteReplacement(value))
         }
         matcher.appendTail(buff)
-        return if (buff.isNotEmpty()) buff.toString() else command
+        return buff.toString()
     }
 
     private val tPattern = Pattern.compile("(\\$[{](?<single>[^$^{}]+)})|(\\$[{]{2}(?<double>[^$^{}]+)[}]{2})")

--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/ReplacementUtils.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/ReplacementUtils.kt
@@ -86,7 +86,7 @@ object ReplacementUtils {
             matcher.appendReplacement(buff, Matcher.quoteReplacement(value))
         }
         matcher.appendTail(buff)
-        return if (buff.isNotEmpty()) buff.toString() else command
+        return buff.toString()
     }
 
     private val tPattern = Pattern.compile("(\\$[{](?<single>[^$^{}]+)})|(\\$[{]{2}(?<double>[^$^{}]+)[}]{2})")

--- a/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/EnvUtilTest.kt
+++ b/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/EnvUtilTest.kt
@@ -77,6 +77,12 @@ class EnvUtilTest {
 
         data["center中"] = "中国"
         parseAndEquals(data = data, template = "abcd_\${center中}_ffs", expect = "abcd_中国_ffs")
+
+        data["blank"] = ""
+        parseAndEquals(data = data, template = "\${blank}", expect = "")
+
+        data["all"] = "hello"
+        parseAndEquals(data = data, template = "\${all}", expect = "hello")
     }
 
     private fun parseAndEquals(
@@ -91,14 +97,10 @@ class EnvUtilTest {
     }
 
     @Test
-    fun parseEnvTest() {
+    fun parseEnvTestContextMap() {
         val map = mutableMapOf<String, String>()
         map["age"] = "1"
         map["name"] = "jacky"
-        val command = "{\"age\": \${age} , \"sex\": \"boy\", \"name\": \${name}}"
-        println(command)
-        val parseEnv = EnvUtils.parseEnv(command, map)
-        println(parseEnv)
 
         val command1 = "hello \${{variables.abc}} world"
         val command2 = "\${{variables.abc}}world"
@@ -146,14 +148,16 @@ class EnvUtilTest {
     }
 
     @Test
-    fun parseEnvTest1() {
+    fun parseEnvTestData() {
         val map = mutableMapOf<String, String>()
-        map["age"] = "1"
+        map["age"] = ""
         map["name"] = "jacky"
         val command = "{\"age\": \${age} , \"sex\": \"boy\", \"name\": \${name}}"
-        println(command)
-        val parseEnv = EnvUtils.parseEnv(command, map)
-        println(parseEnv)
+        println("parseEnvTestData $command")
+        Assert.assertEquals(
+            "{\"age\": ${map["age"]} , \"sex\": \"boy\", \"name\": ${map["name"]}}",
+            EnvUtils.parseEnv(command, map)
+        )
 
         val command1 = "hello \${{variables.abc}} world"
         val command2 = "\${{variables.abc}}world"

--- a/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/ReplacementUtilsTest.kt
+++ b/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/util/ReplacementUtilsTest.kt
@@ -82,6 +82,9 @@ class ReplacementUtilsTest {
 
         data["center中"] = "中国"
         parseAndEquals(data = data, template = "abcd_\${center中}_ffs", expect = "abcd_中国_ffs")
+
+        data["blank"] = ""
+        parseAndEquals(data = data, template = "\${blank}", expect = "")
     }
 
     private fun parseAndEquals(

--- a/src/backend/ci/core/worker/worker-agent/src/main/kotlin/com/tencent/devops/agent/AgentVersion.kt
+++ b/src/backend/ci/core/worker/worker-agent/src/main/kotlin/com/tencent/devops/agent/AgentVersion.kt
@@ -27,7 +27,7 @@
 
 package com.tencent.devops.agent
 
-const val AGENT_VERSION = 12.38 // 此处不能以0结束
+const val AGENT_VERSION = 12.41 // 此处不能以0结束
 
 fun main() {
     println(AGENT_VERSION)


### PR DESCRIPTION
解决当替换后整个字符串都为blank时，被重置回替换前的字符串

