### PR TITLE
feat: 配置全局请求代理功能 #4749 尽早初始化代理配置

### DIFF
--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/OkhttpUtils.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/OkhttpUtils.kt
@@ -45,7 +45,6 @@ import java.io.FileOutputStream
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.security.cert.CertificateException
-import java.util.ArrayList
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
@@ -80,13 +79,17 @@ object OkhttpUtils {
     private const val readTimeout = 30L
     private const val writeTimeout = 30L
 
+    init {
+        logger.info("[OkhttpUtils init]")
+    }
+
     private val okHttpClient = OkHttpClient.Builder()
         .connectTimeout(connectTimeout, TimeUnit.SECONDS)
         .readTimeout(readTimeout, TimeUnit.SECONDS)
         .writeTimeout(writeTimeout, TimeUnit.SECONDS)
         .sslSocketFactory(sslSocketFactory(), trustAllCerts[0] as X509TrustManager)
         .hostnameVerifier { _, _ -> true }
-        .build()!!
+        .build()
 
     // 下载会出现从 文件源--（耗时长）---->网关（网关全部收完才转发给用户，所以用户侧与网关存在读超时的可能)-->用户
     private val longHttpClient = OkHttpClient.Builder()
@@ -95,7 +98,7 @@ object OkhttpUtils {
         .writeTimeout(readTimeout, TimeUnit.MINUTES)
         .sslSocketFactory(sslSocketFactory(), trustAllCerts[0] as X509TrustManager)
         .hostnameVerifier { _, _ -> true }
-        .build()!!
+        .build()
 
     @Throws(UnsupportedEncodingException::class)
     fun joinParams(params: Map<String, String>): String {
@@ -166,7 +169,7 @@ object OkhttpUtils {
             .post(requestBody)
         headers?.forEach { (key, value) ->
             if (!value.isNullOrBlank()) {
-                requestBuilder.addHeader(key, value!!)
+                requestBuilder.addHeader(key, value)
             }
         }
         val request = requestBuilder.build()

--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/GlobalProxyConfiguration.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/GlobalProxyConfiguration.kt
@@ -2,6 +2,8 @@ package com.tencent.devops.common.web
 
 import com.tencent.devops.common.web.proxy.CustomProxySelector
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import java.net.InetSocketAddress
@@ -9,26 +11,32 @@ import java.net.Proxy
 import java.net.ProxySelector
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
+@Configuration("globalProxyConfiguration")
 class GlobalProxyConfiguration(
     /**
      * 是否开启，设置为 true 才生效
      */
+    @Value("\${net.proxy.enable:false}")
     private val enableProxy: String,
     /**
      *  需要代理的hosts，多个使用","隔开，支持正则表达式
      */
+    @Value("\${net.proxy.hosts:}")
     private val proxyHosts: String,
     /**
      *  代理服务器类型，可 HTTP, SOCKS
      */
+    @Value("\${net.proxy.server.type:}")
     private val proxyServerType: String,
     /**
      *  代理服务器主机，host 或者 ip
      */
+    @Value("\${net.proxy.server.host:}")
     private val proxyServerHost: String,
     /**
      *  代理服务器端口
      */
+    @Value("\${net.proxy.server.port:}")
     private val proxyServerPort: String
 ) {
 

--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/WebAutoConfiguration.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/WebAutoConfiguration.kt
@@ -43,6 +43,7 @@ import org.springframework.boot.web.embedded.undertow.UndertowBuilderCustomizer
 import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.DependsOn
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.context.annotation.PropertySource
@@ -60,6 +61,7 @@ import org.springframework.core.env.Environment
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 @AutoConfigureBefore(JerseyAutoConfiguration::class)
 @EnableConfigurationProperties(SwaggerProperties::class)
+@DependsOn("globalProxyConfiguration")
 class WebAutoConfiguration {
 
     @Bean
@@ -103,26 +105,6 @@ class WebAutoConfiguration {
         }
         return factory
     }
-
-    @Bean
-    fun globalProxyConfiguration(
-        @Value("\${net.proxy.enable:false}")
-        enableProxy: String,
-        @Value("\${net.proxy.hosts:}")
-        proxyHosts: String,
-        @Value("\${net.proxy.server.type:}")
-        proxyServerType: String,
-        @Value("\${net.proxy.server.host:}")
-        proxyServerHost: String,
-        @Value("\${net.proxy.server.port:}")
-        proxyServerPort: String
-    ) = GlobalProxyConfiguration(
-        enableProxy = enableProxy,
-        proxyHosts = proxyHosts,
-        proxyServerType = proxyServerType,
-        proxyServerHost = proxyServerHost,
-        proxyServerPort = proxyServerPort
-    )
 
     private val logger = LoggerFactory.getLogger(WebAutoConfiguration::class.java)
 }

--- a/src/backend/ci/core/common/common-web/src/main/resources/META-INF/spring.factories
+++ b/src/backend/ci/core/common/common-web/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.tencent.devops.common.web.GlobalProxyConfiguration,\
 com.tencent.devops.common.web.WebAutoConfiguration,\
 com.tencent.devops.common.web.mq.CoreRabbitMQConfiguration,\
 com.tencent.devops.common.web.mq.ExtendRabbitMQConfiguration,\


### PR DESCRIPTION
com.tencent.devops.common.api.util.OkhttpUtils.okHttpClient 为静态对象，初始化 OkhttpUtils 类就会初始化对象
根据 com.squareup.okhttp3/okhttp/3.9.1/7539531ecf9b6e082fcab195f0835d4f69ead95e/okhttp-3.9.1-sources.jar!/okhttp3/OkHttpClient.java:478 初始化对象时就会选择使用的 ProxySelector