### PR TITLE
流水线的变量单选框类型下拉只能手动写选项，无法从远程服务器获取下拉选项 #5178

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
@@ -256,12 +256,19 @@ class PipelineBuildService(
                 ), startType = startType, channelCode = channelCode
             )
             val paramsWithType = startParamsList.asSequence().plus(
-                BuildParameters(PIPELINE_VERSION, readyToBuildPipelineInfo.version))
+                BuildParameters(PIPELINE_VERSION, readyToBuildPipelineInfo.version)
+            )
                 .plus(BuildParameters(PIPELINE_START_USER_ID, userId))
                 .plus(BuildParameters(PIPELINE_START_TYPE, startType.name))
                 .plus(BuildParameters(PIPELINE_START_CHANNEL, channelCode.name))
                 .plus(BuildParameters(PIPELINE_START_MOBILE, isMobile))
-                .plus(BuildParameters(PIPELINE_NAME, readyToBuildPipelineInfo.pipelineName))
+                .plus(
+                    if (startValues?.containsKey(PIPELINE_NAME) == true) {
+                        BuildParameters(PIPELINE_NAME, startValues[PIPELINE_NAME].toString())
+                    } else {
+                        BuildParameters(PIPELINE_NAME, readyToBuildPipelineInfo.pipelineName)
+                    }
+                )
                 .plus(BuildParameters(PIPELINE_START_USER_NAME, userName ?: userId))
                 .plus(BuildParameters(PIPELINE_BUILD_MSG, buildMsg))
                 .plus(BuildParameters(PIPELINE_CREATE_USER, readyToBuildPipelineInfo.creator))

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
@@ -256,8 +256,7 @@ class PipelineBuildService(
                 ), startType = startType, channelCode = channelCode
             )
             val paramsWithType = startParamsList.asSequence().plus(
-                BuildParameters(PIPELINE_VERSION, readyToBuildPipelineInfo.version)
-            )
+                BuildParameters(PIPELINE_VERSION, readyToBuildPipelineInfo.version))
                 .plus(BuildParameters(PIPELINE_START_USER_ID, userId))
                 .plus(BuildParameters(PIPELINE_START_TYPE, startType.name))
                 .plus(BuildParameters(PIPELINE_START_CHANNEL, channelCode.name))

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
@@ -255,6 +255,7 @@ class PipelineBuildService(
                     key = PIPELINE_BUILD_MSG
                 ), startType = startType, channelCode = channelCode
             )
+            // 增加对containsKey(PIPELINE_NAME)的逻辑判断,如果有传值，默认使用。
             val paramsWithType = startParamsList.asSequence().plus(
                 BuildParameters(PIPELINE_VERSION, readyToBuildPipelineInfo.version))
                 .plus(BuildParameters(PIPELINE_START_USER_ID, userId))


### PR DESCRIPTION
流水线的变量单选框类型下拉只能手动写选项，无法从远程服务器获取下拉选项 #5178