### PR TITLE
feat: 流水线callback增加支持 插件支持执行前暂停&插件继续执行 事件

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/event/CallBackData.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/event/CallBackData.kt
@@ -94,7 +94,8 @@ enum class CallBackEvent {
     BUILD_TASK_START,
     BUILD_TASK_END,
     BUILD_STAGE_START,
-    BUILD_STAGE_END
+    BUILD_STAGE_END,
+    BUILD_TASK_PAUSE
 }
 
 data class PipelineEvent(

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
@@ -344,6 +344,16 @@ class EngineVMBuildService @Autowired(required = false) constructor(
                 // 如果插件配置了前置暂停, 暂停期间关闭当前构建机，节约资源。
                 pipelineTaskService.executePause(taskId = task.taskId, buildId = task.buildId, taskRecord = task)
                 LOG.info("ENGINE|$buildId|taskId=${task.taskId}|taskAtom=${task.taskAtom} cfg pause, shutdown agent")
+                pipelineEventDispatcher.dispatch(PipelineBuildStatusBroadCastEvent(
+                    source = "TaskPause-${task.containerId}-${task.buildId}",
+                    projectId = task.projectId,
+                    pipelineId = task.pipelineId,
+                    userId = task.starter,
+                    buildId = task.buildId,
+                    taskId = task.taskId,
+                    stageId = task.stageId,
+                    actionType = ActionType.REFRESH
+                ))
                 BuildTask(buildId, vmSeqId, BuildTaskStatus.END)
             }
             else -> {

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
@@ -31,6 +31,7 @@ import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.event.dispatcher.pipeline.PipelineEventDispatcher
 import com.tencent.devops.common.event.enums.ActionType
 import com.tencent.devops.common.event.listener.pipeline.BaseListener
+import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildStatusBroadCastEvent
 import com.tencent.devops.common.log.utils.BuildLogPrinter
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.pojo.element.Element
@@ -112,6 +113,15 @@ class PipelineTaskPauseListener @Autowired constructor(
                 projectId = task.projectId,
                 actionType = ActionType.REFRESH,
                 containerType = ""
+            ),
+            PipelineBuildStatusBroadCastEvent(
+                source = "pauseContinue-${task.containerId}-${task.buildId}",
+                projectId = task.projectId,
+                pipelineId = task.pipelineId,
+                userId = task.starter,
+                buildId = task.buildId,
+                taskId = task.taskId,
+                actionType = ActionType.REFRESH
             )
         )
         buildLogPrinter.addYellowLine(

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
@@ -113,15 +113,6 @@ class PipelineTaskPauseListener @Autowired constructor(
                 projectId = task.projectId,
                 actionType = ActionType.REFRESH,
                 containerType = ""
-            ),
-            PipelineBuildStatusBroadCastEvent(
-                source = "pauseContinue-${task.containerId}-${task.buildId}",
-                projectId = task.projectId,
-                pipelineId = task.pipelineId,
-                userId = task.starter,
-                buildId = task.buildId,
-                taskId = task.taskId,
-                actionType = ActionType.REFRESH
             )
         )
         buildLogPrinter.addYellowLine(
@@ -171,6 +162,16 @@ class PipelineTaskPauseListener @Autowired constructor(
                 containerId = task.containerId,
                 stageId = task.stageId,
                 containerType = containerRecord?.containerType ?: "vmBuild"
+            ),
+            PipelineBuildStatusBroadCastEvent(
+                source = "pauseCancel-${task.containerId}-${task.buildId}",
+                projectId = task.projectId,
+                pipelineId = task.pipelineId,
+                userId = task.starter,
+                buildId = task.buildId,
+                taskId = null,
+                stageId = null,
+                actionType = ActionType.END
             )
         )
     }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/CallBackControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/CallBackControl.kt
@@ -142,7 +142,10 @@ class CallBackControl @Autowired constructor(
             } else {
                 if (event.actionType == ActionType.START) {
                     CallBackEvent.BUILD_TASK_START
-                } else {
+                } else if (event.actionType == ActionType.REFRESH) {
+                    CallBackEvent.BUILD_TASK_PAUSE
+                }
+                else {
                     CallBackEvent.BUILD_TASK_END
                 }
             }


### PR DESCRIPTION
1. 暂停时发送 BUILD_TASK_PAUSE
2. 暂停终止发送 BUILD_END事件