### PR TITLE
fix: 处于排队构建状态的流水线无法响应排队超时或队列满的退出信号 #5187

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -2036,8 +2036,8 @@ class PipelineRuntimeService @Autowired constructor(
     fun updateBuildInfoStatus2Queue(projectId: String, buildId: String, oldStatus: BuildStatus) {
         pipelineBuildDao.updateStatus(
             dslContext = dslContext,
-            projectId = buildId,
-            buildId = projectId,
+            projectId = projectId,
+            buildId = buildId,
             oldBuildStatus = oldStatus,
             newBuildStatus = BuildStatus.QUEUE
         )


### PR DESCRIPTION
修正低级错误#5187