### PR TITLE
fix: 第三方构建机agent上报ip优先使用与devops网关通信网卡的ip #3626

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.12
+          go-version: 1.13.15
       - uses: actions/checkout@v2
       - run: make clean build_linux
         working-directory: src/agent/


### PR DESCRIPTION
发布流水线升级相应go版本1.13.15