### PR TITLE
feat: GitUtils支持匹配不带git后缀的仓库地址解析 #5364

### DIFF
--- a/src/backend/ci/core/common/common-scm/src/main/kotlin/com/tencent/devops/scm/utils/code/git/GitUtils.kt
+++ b/src/backend/ci/core/common/common-scm/src/main/kotlin/com/tencent/devops/scm/utils/code/git/GitUtils.kt
@@ -48,6 +48,7 @@ object GitUtils {
         // 兼容http存在端口的情況 http://gitlab.xx:8888/xx.git
         val groups = Regex("git@([-.a-z0-9A-Z]+):(.*).git").find(gitUrl)?.groups
             ?: Regex("http[s]?://([-.a-z0-9A-Z]+)(:[0-9]+)?/(.*).git").find(gitUrl)?.groups
+            ?: Regex("http[s]?://([-.a-z0-9A-Z]+)(:[0-9]+)?/(.*)").find(gitUrl)?.groups
             ?: throw ScmException("Invalid git url $gitUrl", ScmType.CODE_GIT.name)
 
         if (groups.size < 3) {

--- a/src/backend/ci/core/common/common-scm/src/test/kotlin/com/tencent/devops/scm/utils/code/git/GitUtilsTest.kt
+++ b/src/backend/ci/core/common/common-scm/src/test/kotlin/com/tencent/devops/scm/utils/code/git/GitUtilsTest.kt
@@ -93,6 +93,8 @@ class GitUtilsTest {
         assertEquals(repoName, projectName)
         projectName = GitUtils.getProjectName("http://github.com/Tencent/bk-ci.git")
         assertEquals(repoName, projectName)
+        projectName = GitUtils.getProjectName("http://github.com/Tencent/bk-ci")
+        assertEquals(repoName, projectName)
     }
 
     @Test


### PR DESCRIPTION
GitUtils支持匹配不带git后缀的仓库地址解析 #5364