### PR TITLE
fix: 第三方构建机agent上报ip优先使用与devops网关通信网卡的ip #3626

### DIFF
--- a/src/agent/src/pkg/config/config.go
+++ b/src/agent/src/pkg/config/config.go
@@ -97,7 +97,7 @@ func Init() {
 
 func LoadAgentEnv() {
 	GAgentEnv = new(AgentEnv)
-	GAgentEnv.AgentIp = systemutil.GetAgentIp()
+	GAgentEnv.AgentIp = systemutil.GetAgentIp([]string{})
 	GAgentEnv.HostName = systemutil.GetHostName()
 	GAgentEnv.OsName = systemutil.GetOsName()
 	GAgentEnv.SlaveVersion = DetectWorkerVersion()

--- a/src/agent/src/pkg/config/version.go
+++ b/src/agent/src/pkg/config/version.go
@@ -26,4 +26,4 @@
 
 package config
 
-const AgentVersion = "v1.0.10"
+const AgentVersion = "v1.0.11"

--- a/src/agent/src/pkg/heartbeat/heartbeat.go
+++ b/src/agent/src/pkg/heartbeat/heartbeat.go
@@ -27,79 +27,92 @@
 package heartbeat
 
 import (
-	"errors"
-	"time"
+    "errors"
+    "time"
 
-	"github.com/Tencent/bk-ci/src/agent/src/pkg/api"
-	"github.com/Tencent/bk-ci/src/agent/src/pkg/config"
-	"github.com/Tencent/bk-ci/src/agent/src/pkg/job"
-	"github.com/Tencent/bk-ci/src/agent/src/pkg/upgrade"
-	"github.com/Tencent/bk-ci/src/agent/src/pkg/util"
-	"github.com/Tencent/bk-ci/src/agent/src/pkg/util/systemutil"
-	"github.com/astaxie/beego/logs"
+    "github.com/Tencent/bk-ci/src/agent/src/pkg/api"
+    "github.com/Tencent/bk-ci/src/agent/src/pkg/config"
+    "github.com/Tencent/bk-ci/src/agent/src/pkg/job"
+    "github.com/Tencent/bk-ci/src/agent/src/pkg/upgrade"
+    "github.com/Tencent/bk-ci/src/agent/src/pkg/util"
+    "github.com/Tencent/bk-ci/src/agent/src/pkg/util/systemutil"
+    "github.com/astaxie/beego/logs"
 )
 
 func DoAgentHeartbeat() {
-	for {
-		agentHeartbeat()
-		time.Sleep(10 * time.Second)
-	}
+    for {
+        agentHeartbeat()
+        time.Sleep(10 * time.Second)
+    }
 }
 
 func agentHeartbeat() error {
-	result, err := api.Heartbeat(job.GBuildManager.GetInstances())
-	if err != nil {
-		logs.Error("agent heartbeat failed: ", err.Error())
-		return errors.New("agent heartbeat failed")
-	}
-	if result.IsNotOk() {
-		logs.Error("agent heartbeat failed: ", result.Message)
-		return errors.New("agent heartbeat failed")
-	}
+    result, err := api.Heartbeat(job.GBuildManager.GetInstances())
+    if err != nil {
+        logs.Error("agent heartbeat failed: ", err.Error())
+        return errors.New("agent heartbeat failed")
+    }
+    if result.IsNotOk() {
+        logs.Error("agent heartbeat failed: ", result.Message)
+        return errors.New("agent heartbeat failed")
+    }
 
-	heartbeatResponse := new(api.AgentHeartbeatResponse)
-	err = util.ParseJsonToData(result.Data, &heartbeatResponse)
-	if err != nil {
-		logs.Error("agent heartbeat failed: ", err.Error())
-		return errors.New("agent heartbeat failed")
-	}
+    heartbeatResponse := new(api.AgentHeartbeatResponse)
+    err = util.ParseJsonToData(result.Data, &heartbeatResponse)
+    if err != nil {
+        logs.Error("agent heartbeat failed: ", err.Error())
+        return errors.New("agent heartbeat failed")
+    }
 
-	if heartbeatResponse.AgentStatus == config.AgentStatusDelete {
-		upgrade.UninstallAgent()
-		return nil
-	}
+    if heartbeatResponse.AgentStatus == config.AgentStatusDelete {
+        upgrade.UninstallAgent()
+        return nil
+    }
 
-	// agent配置
-	configChanged := false
-	if config.GAgentConfig.ParallelTaskCount != heartbeatResponse.ParallelTaskCount {
-		config.GAgentConfig.ParallelTaskCount = heartbeatResponse.ParallelTaskCount
-		configChanged = true
-	}
-	if heartbeatResponse.Gateway != "" && heartbeatResponse.Gateway != config.GAgentConfig.Gateway {
-		config.GAgentConfig.Gateway = heartbeatResponse.Gateway
-		systemutil.DevopsGateway = heartbeatResponse.Gateway
-		configChanged = true
-	}
-	if heartbeatResponse.FileGateway != "" && heartbeatResponse.FileGateway != config.GAgentConfig.FileGateway {
-		config.GAgentConfig.FileGateway = heartbeatResponse.FileGateway
-		configChanged = true
-	}
-	if configChanged {
-		config.GAgentConfig.SaveConfig()
-	}
+    // agent配置
+    configChanged := false
+    if config.GAgentConfig.ParallelTaskCount != heartbeatResponse.ParallelTaskCount {
+        config.GAgentConfig.ParallelTaskCount = heartbeatResponse.ParallelTaskCount
+        configChanged = true
+    }
+    if heartbeatResponse.Gateway != "" && heartbeatResponse.Gateway != config.GAgentConfig.Gateway {
+        config.GAgentConfig.Gateway = heartbeatResponse.Gateway
+        systemutil.DevopsGateway = heartbeatResponse.Gateway
+        configChanged = true
+    }
+    if heartbeatResponse.FileGateway != "" && heartbeatResponse.FileGateway != config.GAgentConfig.FileGateway {
+        config.GAgentConfig.FileGateway = heartbeatResponse.FileGateway
+        configChanged = true
+    }
+    if configChanged {
+        config.GAgentConfig.SaveConfig()
+    }
 
-	// agent环境变量
-	config.GEnvVars = heartbeatResponse.Envs
+    // agent环境变量
+    config.GEnvVars = heartbeatResponse.Envs
 
-	// 检测agent版本与agent文件是否匹配
-	if config.AgentVersion != heartbeatResponse.MasterVersion {
-		agentFileVersion := config.DetectAgentVersion()
-		if agentFileVersion != "" && config.AgentVersion != agentFileVersion {
-			logs.Warn("agent version mismatch, exiting agent process")
-			systemutil.ExitProcess(1)
-		}
-	}
+    // 从环境管理->构建机详情-->环境变量增加该环境变量，用于忽略一些特殊的VPN产生的VPN
+    /*
+      忽略一些在Windows机器上VPN代理软件所产生的虚拟网卡（有Mac地址）的IP，一般这类IP
+      更像是一些路由器的192开头的IP，属于干扰IP，安装了这类软件的windows机器IP都会变成相同，所以需要忽略掉
+    */
+    ignoreLocalVpnIPs := config.GEnvVars["DEVOPS_IGNORE_LOCAL_VPN_IPS"]
+    if len(ignoreLocalVpnIPs) > 0 {
+        splitIps := util.SplitAndTrimSpace(ignoreLocalVpnIPs, ",")
+        if util.Contains(splitIps, config.GAgentEnv.AgentIp) { // Agent检测到的IP与要忽略的本地VPN IP相同，则更换真正IP
+            config.GAgentEnv.AgentIp = systemutil.GetAgentIp(splitIps)
+        }
+    }
 
-	logs.Info("agent heartbeat done")
-	return nil
+    // 检测agent版本与agent文件是否匹配
+    if config.AgentVersion != heartbeatResponse.MasterVersion {
+        agentFileVersion := config.DetectAgentVersion()
+        if agentFileVersion != "" && config.AgentVersion != agentFileVersion {
+            logs.Warn("agent version mismatch, exiting agent process")
+            systemutil.ExitProcess(1)
+        }
+    }
+
+    logs.Info("agent heartbeat done")
+    return nil
 }

--- a/src/agent/src/pkg/util/systemutil/systemutil_test.go
+++ b/src/agent/src/pkg/util/systemutil/systemutil_test.go
@@ -44,5 +44,5 @@ func Test_IP(t *testing.T) {
 }
 
 func Test_GetAgentIp(t *testing.T) {
-	t.Log(systemutil.GetAgentIp())
+	t.Log(systemutil.GetAgentIp([]string{}))
 }

--- a/src/agent/src/pkg/util/util.go
+++ b/src/agent/src/pkg/util/util.go
@@ -27,24 +27,46 @@
 package util
 
 import (
-	"encoding/json"
-	"time"
+    "encoding/json"
+    "strings"
+    "time"
 )
 
 func ParseJsonToData(jsonData interface{}, targetData interface{}) error {
-	dataStr, err := json.Marshal(jsonData)
-	if err != nil {
-		return err
-	}
+    dataStr, err := json.Marshal(jsonData)
+    if err != nil {
+        return err
+    }
 
-	err = json.Unmarshal([]byte(dataStr), targetData)
-	if err != nil {
-		return err
-	} else {
-		return nil
-	}
+    err = json.Unmarshal([]byte(dataStr), targetData)
+    if err != nil {
+        return err
+    } else {
+        return nil
+    }
 }
 
-func FormatTime(t time.Time) string{
-	return t.Format("2006-01-02 15:04:05")
+func FormatTime(t time.Time) string {
+    return t.Format("2006-01-02 15:04:05")
+}
+
+func SplitAndTrimSpace(s string, sep string) []string {
+    split := strings.Split(s, sep)
+    result := make([]string, len(split))
+    for i, sub := range split {
+        result[i] = strings.TrimSpace(sub)
+    }
+    return result
+}
+func Contains(s []string, subs string) bool {
+    if len(s) <= 0 {
+        return false
+    }
+
+    for _, a := range s {
+        if a == subs {
+            return true
+        }
+    }
+    return false
 }


### PR DESCRIPTION
支持通过构建机详情设置DEVOPS_IGNORE_LOCAL_VPN_IP环境变量，忽略一些在Windows机器上VPN代理软件所产生的虚拟网卡（有Mac地址）的IP，
一般这类IP更像是一些路由器的192开头的IP，属于干扰IP，安装了这类软件的windows机器IP都会变成相同，所以需要忽略掉,用户在界面上导致无法识别