### PR TITLE
模板实例管理页面，搜索框右侧icon错位 

### DIFF
--- a/src/frontend/devops-pipeline/src/views/template/instance.vue
+++ b/src/frontend/devops-pipeline/src/views/template/instance.vue
@@ -17,6 +17,7 @@
                 </div>
                 <bk-input
                     :placeholder="$t('search')"
+                    ext-cls="instance-handle-row-right"
                     :clearable="true"
                     right-icon="icon-search"
                     v-model="searchKey"
@@ -439,6 +440,11 @@
                 margin-right: 4px;
                 padding: 0 11px;
                 font-size: 12px;
+            }
+        }
+        .instance-handle-row-right {
+            .right-icon {
+                top: 16px;
             }
         }
         .instance-table {


### PR DESCRIPTION
fix: 模板实例管理页面，搜索框右侧icon错位 issue #5449