### PR TITLE
bug: 流水线取消执行后，流水线列表页的流水线进度不应有进度

### DIFF
--- a/src/frontend/devops-pipeline/src/views/list/newlist.vue
+++ b/src/frontend/devops-pipeline/src/views/list/newlist.vue
@@ -400,7 +400,7 @@
 
                 const calcTime = Math.ceil((time - latestBuildStartTime) / (latestBuildEstimatedExecutionSeconds * 100 * 1000))
 
-                if (this.statusMap[item.latestBuildStatus] === 'error') {
+                if (this.statusMap[item.latestBuildStatus] === 'error' || this.statusMap[item.latestBuildStatus] === 'cancel') {
                     return '100%'
                 }
 


### PR DESCRIPTION
bug: 流水线取消执行后，流水线列表页的流水线进度不应有进度 issue #5496