### PR TITLE
bug: 暂停偶现无法终止 #5530

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
@@ -551,7 +551,6 @@ class EngineVMBuildService @Autowired(required = false) constructor(
             val task = pipelineRuntimeService.listContainerBuildTasks(buildId, vmSeqId)
                 .firstOrNull { it.taskId == VMUtils.genEndPointTaskId(it.taskSeq) }
 
-            buildingHeartBeatUtils.dropHeartbeat(buildId = buildId, vmSeqId = vmSeqId)
             return if (task == null || task.status.isFinish()) {
                 LOG.warn("ENGINE|$buildId|Agent|$vmName|END_JOB|j($vmSeqId)|Task[${task?.taskName}] ${task?.status}")
                 false

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMShutdownTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/atom/vm/DispatchVMShutdownTaskAtom.kt
@@ -35,6 +35,7 @@ import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.process.engine.atom.AtomResponse
 import com.tencent.devops.process.engine.atom.IAtomTask
 import com.tencent.devops.process.engine.atom.defaultFailAtomResponse
+import com.tencent.devops.process.engine.control.BuildingHeartBeatUtils
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask
 import com.tencent.devops.process.pojo.mq.PipelineAgentShutdownEvent
 import org.slf4j.LoggerFactory
@@ -47,7 +48,8 @@ import org.springframework.stereotype.Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 class DispatchVMShutdownTaskAtom @Autowired constructor(
     private val buildLogPrinter: BuildLogPrinter,
-    private val pipelineEventDispatcher: PipelineEventDispatcher
+    private val pipelineEventDispatcher: PipelineEventDispatcher,
+    private val buildingHeartBeatUtils: BuildingHeartBeatUtils
 ) : IAtomTask<VMBuildContainer> {
     override fun getParamElement(task: PipelineBuildTask): VMBuildContainer {
         return JsonUtil.mapTo(task.taskParams, VMBuildContainer::class.java)
@@ -88,6 +90,9 @@ class DispatchVMShutdownTaskAtom @Autowired constructor(
             jobId = task.containerHashId ?: "",
             executeCount = task.executeCount
         )
+
+        // issues_5530 stop时关闭心跳
+        buildingHeartBeatUtils.dropHeartbeat(buildId = buildId, vmSeqId = vmSeqId)
 
         logger.info("[$buildId]|SHUTDOWN_VM|stageId=${task.stageId}|container=${task.containerId}|vmSeqId=$vmSeqId")
         return AtomResponse(BuildStatus.SUCCEED)

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/HeartbeatControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/HeartbeatControl.kt
@@ -52,7 +52,7 @@ class HeartbeatControl @Autowired constructor(
 ) {
 
     companion object {
-        private const val TIMEOUT_IN_MS = 2 * 60 * 1000 // timeout in 2 minutes
+        private const val TIMEOUT_IN_MS = 10 * 60 * 1000 // timeout in 10 minutes
         private val LOG = LoggerFactory.getLogger(HeartbeatControl::class.java)
         private const val LOG_PER_TIMES = 5 // ?次打一次日志
     }

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -378,10 +378,10 @@ class StartActionTaskContainerCmd(
             // issues_5530 stop插件执行后会发送shutdown,无需构建机再跑endBuild逻辑,避免造成并发问题。
             // 若stop先到，endBuild未执行。则end插件就一直处于queue状态。导致暂停插件无法终止。
             if (endTask != null) {
-                taskBuildDetailService.taskEnd(
-                    buildId = endTask.buildId,
+                pipelineRuntimeService.updateTaskStatus(
+                    task = endTask!!,
                     buildStatus = BuildStatus.CANCELED,
-                    taskId = endTask.taskId,
+                    userId = "system"
                 )
             }
         }

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -380,8 +380,8 @@ class StartActionTaskContainerCmd(
             if (endTask != null && endTask.status != BuildStatus.RUNNING) {
                 pipelineRuntimeService.updateTaskStatus(
                     task = endTask!!,
-                    buildStatus = BuildStatus.CANCELED,
-                    userId = "system"
+                    buildStatus = BuildStatus.SUCCEED,
+                    userId = endTask.starter
                 )
             }
         }

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -379,7 +379,7 @@ class StartActionTaskContainerCmd(
             // 若stop先到，endBuild未执行。则end插件就一直处于queue状态。导致暂停插件无法终止。
             if (endTask != null && endTask.status != BuildStatus.RUNNING) {
                 pipelineRuntimeService.updateTaskStatus(
-                    task = endTask!!,
+                    task = endTask,
                     buildStatus = BuildStatus.SUCCEED,
                     userId = endTask.starter
                 )

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -372,6 +372,18 @@ class StartActionTaskContainerCmd(
             toDoTask = pipelineBuildTask
             LOG.info("ENGINE|${currentTask.buildId}|findNextTaskAfterPause|PAUSE|${currentTask.stageId}|" +
                 "j(${currentTask.containerId})|${currentTask.taskId}|NextTask=${toDoTask.taskId}")
+            val endTask = containerContext.containerTasks
+                .filter { it.taskId.startsWith(VMUtils.getEndLabel()) } // 获取end插件
+                .getOrNull(0)
+            // issues_5530 stop插件执行后会发送shutdown,无需构建机再跑endBuild逻辑,避免造成并发问题。
+            // 若stop先到，endBuild未执行。则end插件就一直处于queue状态。导致暂停插件无法终止。
+            if (endTask != null) {
+                taskBuildDetailService.taskEnd(
+                    buildId = endTask.buildId,
+                    buildStatus = BuildStatus.CANCELED,
+                    taskId = endTask.taskId,
+                )
+            }
         }
 
         // 终止打印终止原因

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -377,7 +377,7 @@ class StartActionTaskContainerCmd(
                 .getOrNull(0)
             // issues_5530 stop插件执行后会发送shutdown,无需构建机再跑endBuild逻辑,避免造成并发问题。
             // 若stop先到，endBuild未执行。则end插件就一直处于queue状态。导致暂停插件无法终止。
-            if (endTask != null) {
+            if (endTask != null && endTask.status != BuildStatus.RUNNING) {
                 pipelineRuntimeService.updateTaskStatus(
                     task = endTask!!,
                     buildStatus = BuildStatus.CANCELED,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/CallBackControl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/engine/control/CallBackControl.kt
@@ -224,7 +224,7 @@ class CallBackControl @Autowired constructor(
             callbackClient.newCall(request).execute()
         } catch (e: Exception) {
             logger.warn("BKSystemErrorMonitor|[${callBack.projectId}]|CALL_BACK|" +
-                "url=${callBack.callBackUrl}|${callBack.events}", e)
+                "url=${callBack.callBackUrl}|${callBack.events}|$requestBody", e)
             errorMsg = e.message
             status = ProjectPipelineCallbackStatus.FAILED
         } finally {

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt
@@ -189,10 +189,7 @@ object Runner {
                     logger.info("WAIT $sleepMills ms")
                     Thread.sleep(sleepMills)
                 }
-                BuildTaskStatus.END -> {
-                    Thread.sleep(maxSleepStep * millsStep)
-                    break@loop
-                }
+                BuildTaskStatus.END -> break@loop
             }
         }
 

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt
@@ -189,7 +189,10 @@ object Runner {
                     logger.info("WAIT $sleepMills ms")
                     Thread.sleep(sleepMills)
                 }
-                BuildTaskStatus.END -> break@loop
+                BuildTaskStatus.END -> {
+                    Thread.sleep(maxSleepStep * millsStep)
+                    break@loop
+                }
             }
         }
 


### PR DESCRIPTION
stop插件执行后会发送shutdown,无需构建机再跑endBuild逻辑,避免造成并发问题。
若stop先到，endBuild未执行。则end插件就一直处于queue状态。导致暂停插件无法终止。