### PR TITLE
流水线中插件配置的查看态，group无法展开收起

### DIFF
--- a/src/frontend/devops-pipeline/src/components/AtomPropertyPanel/AtomOption.vue
+++ b/src/frontend/devops-pipeline/src/components/AtomPropertyPanel/AtomOption.vue
@@ -125,6 +125,9 @@
 </script>
 
 <style lang="scss">
+    .header {
+        pointer-events: auto;
+    }
     .atom-control-option {
         position: relative;
         .atom-checkbox-list-item {


### PR DESCRIPTION
fix: 流水线中插件配置的查看态，group无法展开收起 issue #3014