### PR TITLE
取消windows&macos devopsDaemon自动升级

### DIFF
--- a/src/agent/src/cmd/daemon/main.go
+++ b/src/agent/src/cmd/daemon/main.go
@@ -51,6 +51,11 @@ const (
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "version" {
+		fmt.Println(config.AgentVersion)
+		systemutil.ExitProcess(0)
+	}
+
 	runtime.GOMAXPROCS(4)
 
 	workDir := systemutil.GetExecutableDir()

--- a/src/agent/src/cmd/daemon/main_win.go
+++ b/src/agent/src/cmd/daemon/main_win.go
@@ -29,6 +29,7 @@
 package main
 
 import (
+	"fmt"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -44,6 +45,10 @@ import (
 const daemonProcess = "daemon"
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "version" {
+		fmt.Println(config.AgentVersion)
+		systemutil.ExitProcess(0)
+	}
 	runtime.GOMAXPROCS(4)
 
 	workDir := systemutil.GetExecutableDir()

--- a/src/agent/src/pkg/config/version.go
+++ b/src/agent/src/pkg/config/version.go
@@ -26,4 +26,4 @@
 
 package config
 
-const AgentVersion = "v1.7.0"
+const AgentVersion = "v1.7.1"

--- a/src/agent/src/pkg/config/version.go
+++ b/src/agent/src/pkg/config/version.go
@@ -26,4 +26,4 @@
 
 package config
 
-const AgentVersion = "v1.7.1"
+const AgentVersion = "v1.7.20"

--- a/src/agent/src/pkg/upgrade/operation.go
+++ b/src/agent/src/pkg/upgrade/operation.go
@@ -51,14 +51,14 @@ func UninstallAgent() {
 }
 
 func runUpgrader(action string) error {
-	logs.Info("start upgrader process")
+	logs.Info("[agentUpgrade]|start upgrader process")
 
 	scripPath := systemutil.GetUpgradeDir() + "/" + config.GetClientUpgraderFile()
 
 	if !systemutil.IsWindows() {
 		err := os.Chmod(scripPath, 0777)
 		if err != nil {
-			logs.Error("chmod failed: ", err.Error())
+			logs.Error("[agentUpgrade]|chmod failed: ", err.Error())
 			return errors.New("chmod failed: ")
 		}
 	}
@@ -70,18 +70,18 @@ func runUpgrader(action string) error {
 
 	pid, err := command.StartProcess(scripPath, args, systemutil.GetWorkDir(), nil, "")
 	if err != nil {
-		logs.Error("run upgrader failed: ", err.Error())
+		logs.Error("[agentUpgrade]|run upgrader failed: ", err.Error())
 		return errors.New("run upgrader failed")
 	}
-	logs.Info("start process success, pid: ", pid)
+	logs.Info("[agentUpgrade]|start process success, pid: ", pid)
 
-	logs.Warning("agent process exiting")
+	logs.Warning("[agentUpgrade]|agent process exiting")
 	systemutil.ExitProcess(0)
 	return nil
 }
 
 func DoUpgradeOperation(agentChanged bool, workAgentChanged bool) error {
-	logs.Info("start upgrade, agent changed: ", agentChanged, ", work agent changed: ", workAgentChanged)
+	logs.Info("[agentUpgrade]|start upgrade, agent changed: ", agentChanged, ", work agent changed: ", workAgentChanged)
 	config.GIsAgentUpgrading = true
 	defer func() {
 		config.GIsAgentUpgrading = false
@@ -89,33 +89,33 @@ func DoUpgradeOperation(agentChanged bool, workAgentChanged bool) error {
 	}()
 
 	if !agentChanged && !workAgentChanged {
-		logs.Info("no change to upgrade, skip")
+		logs.Info("[agentUpgrade]|no change to upgrade, skip")
 		return nil
 	}
 
 	if workAgentChanged {
-		logs.Info("work agent changed, replace work agent file")
+		logs.Info("[agentUpgrade]|work agent changed, replace work agent file")
 		_, err := fileutil.CopyFile(
 			systemutil.GetUpgradeDir()+"/"+config.WorkAgentFile,
 			systemutil.GetWorkDir()+"/"+config.WorkAgentFile,
 			true)
 		if err != nil {
-			logs.Error("replace work agent file failed: ", err.Error())
+			logs.Error("[agentUpgrade]|replace work agent file failed: ", err.Error())
 			return errors.New("replace work agent file failed")
 		}
-		logs.Info("relace agent file done")
+		logs.Info("[agentUpgrade]|relace agent file done")
 
 		config.GAgentEnv.SlaveVersion = config.DetectWorkerVersion()
 	}
 
 	if agentChanged {
-		logs.Info("agent changed, start upgrader")
+		logs.Info("[agentUpgrade]|agent changed, start upgrader")
 		err := runUpgrader(config.ActionUpgrade)
 		if err != nil {
 			return err
 		}
 	} else {
-		logs.Info("agent not changed, skip agent upgrade")
+		logs.Info("[agentUpgrade]|agent not changed, skip agent upgrade")
 	}
 	return nil
 }

--- a/src/agent/src/pkg/upgrade/upgrade.go
+++ b/src/agent/src/pkg/upgrade/upgrade.go
@@ -50,35 +50,35 @@ func DoPollAndUpgradeAgent() {
 func agentUpgrade() {
 	checkResult, err := api.CheckUpgrade()
 	if err != nil {
-		logs.Error("check upgrade err: ", err.Error())
+		logs.Error("[agentUpgrade]|check upgrade err: ", err.Error())
 		return
 	}
 	if !checkResult.IsOk() {
-		logs.Error("check upgrade failed: ", checkResult.Message)
+		logs.Error("[agentUpgrade]|check upgrade failed: ", checkResult.Message)
 		return
 	}
 
 	if checkResult.IsAgentDelete() {
-		logs.Info("agent is deleted, skip")
+		logs.Info("[agentUpgrade]|agent is deleted, skip")
 		return
 	}
 
 	if !(checkResult.Data).(bool) {
-		logs.Info("no need to upgrade agent, skip")
+		logs.Info("[agentUpgrade]|no need to upgrade agent, skip")
 		return
 	}
 
-	logs.Info("download upgrade files start")
+	logs.Info("[agentUpgrade]|download upgrade files start")
 	agentChanged, workerChanged, err := downloadUpgradeFiles()
 	if err != nil {
-		logs.Error("download upgrade files failed", err.Error())
+		logs.Error("[agentUpgrade]|download upgrade files failed", err.Error())
 		return
 	}
-	logs.Info("download upgrade files done")
+	logs.Info("[agentUpgrade]|download upgrade files done")
 
 	err = DoUpgradeOperation(agentChanged, workerChanged)
 	if err != nil {
-		logs.Error("do upgrade operation failed", err)
+		logs.Error("[agentUpgrade]|do upgrade operation failed", err)
 	}
 }
 
@@ -87,51 +87,51 @@ func downloadUpgradeFiles() (agentChanged bool, workAgentChanged bool, err error
 	upgradeDir := systemutil.GetUpgradeDir()
 	os.MkdirAll(upgradeDir, os.ModePerm)
 
-	logs.Info("download upgrader start")
+	logs.Info("[agentUpgrade]|download upgrader start")
 	_, err = api.DownloadUpgradeFile("upgrade/"+config.GetServerUpgraderFile(), upgradeDir+"/"+config.GetClientUpgraderFile())
 	if err != nil {
-		logs.Error("download upgrader failed", err)
+		logs.Error("[agentUpgrade]|download upgrader failed", err)
 		return false, false, errors.New("download upgrader failed")
 	}
-	logs.Info("download upgrader done")
+	logs.Info("[agentUpgrade]|download upgrader done")
 
-	logs.Info("download daemon start")
+	logs.Info("[agentUpgrade]|download daemon start")
 	newDaemonMd5, err := api.DownloadUpgradeFile("upgrade/"+config.GetServerDaemonFile(), upgradeDir+"/"+config.GetClientDaemonFile())
 	if err != nil {
-		logs.Error("download daemon failed", err)
+		logs.Error("[agentUpgrade]|download daemon failed", err)
 		return false, false, errors.New("download daemon failed")
 	}
-	logs.Info("download daemon done")
+	logs.Info("[agentUpgrade]|download daemon done")
 
-	logs.Info("download agent start")
+	logs.Info("[agentUpgrade]|download agent start")
 	newAgentMd5, err := api.DownloadUpgradeFile("upgrade/"+config.GetServerAgentFile(), upgradeDir+"/"+config.GetClienAgentFile())
 	if err != nil {
-		logs.Error("download agent failed", err)
+		logs.Error("[agentUpgrade]|download agent failed", err)
 		return false, false, errors.New("download agent failed")
 	}
-	logs.Info("download agent done")
+	logs.Info("[agentUpgrade]|download agent done")
 
-	logs.Info("download worker start")
+	logs.Info("[agentUpgrade]|download worker start")
 	newWorkerMd5, err := api.DownloadUpgradeFile("jar/"+config.WorkAgentFile, upgradeDir+"/"+config.WorkAgentFile)
 	if err != nil {
-		logs.Error("download worker failed", err)
+		logs.Error("[agentUpgrade]|download worker failed", err)
 		return false, false, errors.New("download worker failed")
 	}
-	logs.Info("download worker done")
+	logs.Info("[agentUpgrade]|download worker done")
 
 	daemonMd5, err := fileutil.GetFileMd5(workDir + "/" + config.GetClientDaemonFile())
 	if err != nil {
-		logs.Error("check daemon md5 failed", err)
+		logs.Error("[agentUpgrade]|check daemon md5 failed", err)
 		return false, false, errors.New("check daemon md5 failed")
 	}
 	agentMd5, err := fileutil.GetFileMd5(workDir + "/" + config.GetClienAgentFile())
 	if err != nil {
-		logs.Error("check agent md5 failed", err)
+		logs.Error("[agentUpgrade]|check agent md5 failed", err)
 		return false, false, errors.New("check agent md5 failed")
 	}
 	workerMd5, err := fileutil.GetFileMd5(workDir + "/" + config.WorkAgentFile)
 	if err != nil {
-		logs.Error("check worker md5 failed", err)
+		logs.Error("[agentUpgrade]|check worker md5 failed", err)
 		return false, false, errors.New("check agent md5 failed")
 	}
 

--- a/src/agent/src/pkg/upgrader/upgrader.go
+++ b/src/agent/src/pkg/upgrader/upgrader.go
@@ -41,6 +41,11 @@ import (
 	"github.com/gofrs/flock"
 )
 
+const (
+	agentProcess  = "agent"
+	daemonProcess = "daemon"
+)
+
 func DoUpgradeAgent() error {
 	logs.Info("start upgrade agent")
 	config.Init()
@@ -51,58 +56,83 @@ func DoUpgradeAgent() error {
 		logs.Error("get total lock failed, exit", err.Error())
 		return errors.New("get total lock failed")
 	}
-    defer func() { totalLock.Unlock() }()
-	serr := StopAgent()
-	if serr != nil {
-		logs.Error("stop agent failed: ", err.Error())
-		return err
+	defer func() { totalLock.Unlock() }()
+
+	daemonChange, _ := checkUpgradeFileChange(config.GetClientDaemonFile())
+	/*
+	#4686
+	 1、kill devopsDaemon进程的行为在 macos 下， 如果当前是由 launchd 启动的（比如mac重启之后，devopsDaemon会由launchd接管启动）
+		当upgrader进程触发kill devopsDaemon时，会导致当前upgrader进程也被系统一并停掉，所以要排除macos的进程停止操作，否则会导致升级中断
+
+	 2、windows 因早期daemon缺失 pid文件，在安装多个agent的机器上无法很正确的寻找到正确的进程，并且windows的启动方式较多，早期用户会使用
+	直接双击devopsDaemon.exe文件来启动，以此来保证构建进程能够正确拉起带UI的程序，所以这块无法正确查找到进程，因此暂时也不考虑windows的
+	devopsDaemon.exe文件升级。 windows需要手动升级
+	 */
+	if daemonChange && systemutil.IsLinux() {
+		tryKillAgentProcess(daemonProcess) // macos 在升级后只能使用手动重启
 	}
 
-	logs.Info("wait 5 seconds for agent to stop")
-	time.Sleep(5 * time.Second)
-
-	err = replaceAgentFile(config.GetClienAgentFile())
-	if err != nil {
-		logs.Error("replace agent file failed: ", err.Error())
-		return errors.New("replace agent file failed: " + err.Error())
+	agentChange, _ := checkUpgradeFileChange(config.GetClienAgentFile())
+	if agentChange {
+		tryKillAgentProcess(agentProcess)
 	}
 
-	err = replaceAgentFile(config.GetClientDaemonFile()) // 如果daemon进程仍然存在，则会替换失败，但以下也会退出
-
-	if err != nil {
-		logs.Error("replace daemon file failed: ", err.Error())
+	if !agentChange && !daemonChange {
+		logs.Info("upgrade nothing, exit")
+		return nil
 	}
 
-	err2 := StartAgent()
-	if err2 != nil {
-		logs.Error("start daemon failed: ", err.Error())
-		return err2
+	logs.Info("wait 2 seconds for agent to stop")
+	time.Sleep(2 * time.Second)
+
+	if agentChange {
+		err = replaceAgentFile(config.GetClienAgentFile())
+		if err != nil {
+			logs.Error("replace agent file failed: ", err.Error())
+		}
 	}
-	logs.Info("agent start done")
+
+	if daemonChange {
+		err = replaceAgentFile(config.GetClientDaemonFile()) // #4686 如果windows下daemon进程仍然存在，则会替换失败
+		if err != nil {
+			logs.Error("replace daemon file failed: ", err.Error())
+		}
+		if systemutil.IsLinux() { // #4686 如上，上面仅停止Linux的devopsDaemon进程，则也只重启动Linux的
+			if startErr := StartDaemon(); startErr != nil {
+				logs.Error("start daemon failed: ", startErr.Error())
+				return startErr
+			}
+			logs.Info("agent start done")
+		}
+	}
 	logs.Info("agent upgrade done, upgrade process exiting")
 	return nil
 }
 
-func tryKillAgentProcess() {
-	logs.Info("try kill agent process")
-	pidFile := fmt.Sprintf("%s/agent.pid", systemutil.GetRuntimeDir())
+func tryKillAgentProcess(processName string) {
+	logs.Info(fmt.Sprintf("try kill %s process", processName))
+	pidFile := fmt.Sprintf("%s/%s.pid", systemutil.GetRuntimeDir(), processName)
 	agentPid, err := fileutil.GetString(pidFile)
 	if err != nil {
-		logs.Warn("read pid failed")
+		logs.Warn(fmt.Sprintf("parse %s pid failed: %s", processName, err))
 		return
 	}
 	intPid, err := strconv.Atoi(agentPid)
 	if err != nil {
-		logs.Warn("parse pid failed")
+		logs.Warn(fmt.Sprintf("parse %s pid: %s failed", processName, agentPid))
 		return
 	}
 	process, err := os.FindProcess(intPid)
 	if err != nil || process == nil {
-		logs.Warn("find process failed")
+		logs.Warn(fmt.Sprintf("find %s process pid: %s failed", processName, agentPid))
 		return
 	} else {
-		logs.Info("kill agent process, pid: ", intPid)
-		process.Kill()
+		logs.Info(fmt.Sprintf("kill %s process, pid: %s", processName, agentPid))
+		err = process.Kill()
+		if err != nil {
+			logs.Warn(fmt.Sprintf("kill %s pid: %s failed: %s", processName, agentPid, err))
+			return
+		}
 	}
 }
 
@@ -130,6 +160,44 @@ func UninstallAgent() error {
 	return nil
 }
 
+func checkUpgradeFileChange(fileName string) (change bool, err error) {
+
+	oldMd5, err := fileutil.GetFileMd5(systemutil.GetWorkDir() + "/" + fileName)
+	if err != nil {
+		logs.Error(fmt.Sprintf("[agentUpgrade]|check %s md5 failed", fileName), err)
+		return false, errors.New("check old md5 failed")
+	}
+
+	newMd5, err := fileutil.GetFileMd5(systemutil.GetUpgradeDir() + "/" + fileName)
+	if err != nil {
+		logs.Error(fmt.Sprintf("[agentUpgrade]|check %s md5 failed", fileName), err)
+		return false, errors.New("check new md5 failed")
+	}
+
+	return oldMd5 != newMd5, nil
+}
+
+func StartDaemon() error {
+	logs.Info("starting ", config.GetClientDaemonFile())
+
+	workDir := systemutil.GetWorkDir()
+	startCmd := workDir + "/" + config.GetClientDaemonFile()
+
+
+	if err := fileutil.SetExecutable(startCmd); err != nil {
+		logs.Warn(fmt.Errorf("chmod daemon file failed: %v", err))
+		return err
+	}
+
+	pid, err := command.StartProcess(startCmd, nil, workDir, nil, "")
+	logs.Info("pid: ", pid)
+	if err != nil {
+		logs.Error("run start daemon failed: ", err.Error())
+		return err
+	}
+	return nil
+}
+
 func StopAgent() error {
 	logs.Info("start stop agent")
 
@@ -145,46 +213,17 @@ func StopAgent() error {
 	return nil
 }
 
-func StartAgent() error {
-	logs.Info("start agent")
-
-	workDir := systemutil.GetWorkDir()
-	startCmd := workDir + "/" + config.GetStartScript()
-	output, err := command.RunCommand(startCmd, []string{} /*args*/, workDir, nil)
-	if err != nil {
-		logs.Error("run start script failed: ", err.Error())
-		logs.Error("output: ", string(output))
-		return errors.New("run start script failed")
-	}
-	logs.Info("output: ", string(output))
-	return nil
-}
-
 func replaceAgentFile(fileName string) error {
 	logs.Info("replace agent file: ", fileName)
 	src := systemutil.GetUpgradeDir() + "/" + fileName
 	dst := systemutil.GetWorkDir() + "/" + fileName
-	_, err := fileutil.CopyFile(src, dst, true)
-	return err
-}
-
-func InstallAgent() error {
-	logs.Info("start install agent")
-
-	workDir := systemutil.GetWorkDir()
-	startCmd := workDir + "/" + config.GetInstallScript()
-
-	err := fileutil.SetExecutable(startCmd)
-	if err != nil {
-		return fmt.Errorf("chmod install script failed: %s", err.Error())
+	if _, err := fileutil.CopyFile(src, dst, true); err != nil {
+		logs.Warn(fmt.Sprintf("copy file %s to %s failed: %s", src, dst, err))
+		return err
 	}
-
-	output, err := command.RunCommand(startCmd, []string{} /*args*/, workDir, nil)
-	if err != nil {
-		logs.Error("run install script failed: ", err.Error())
-		logs.Error("output: ", string(output))
-		return errors.New("run install script failed")
+	if err := fileutil.SetExecutable(dst); err != nil {
+		logs.Warn(fmt.Sprintf("chmod %s file failed: %s", dst, err))
+		return err
 	}
-	logs.Info("output: ", string(output))
 	return nil
 }

--- a/src/agent/src/pkg/util/httputil/httputil.go
+++ b/src/agent/src/pkg/util/httputil/httputil.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/Tencent/bk-ci/src/agent/src/pkg/config"
 	"github.com/astaxie/beego/logs"
 	"io"
@@ -127,7 +128,7 @@ func (r *HttpClient) Body(body interface{}) *HttpClient {
 	}
 	r.body = bytes.NewReader(data)
 
-	logs.Info("body: ", string(data))
+	logs.Info(fmt.Sprintf("url:[%s]|request body: %s", r.url, string(data)))
 	return r
 }
 
@@ -135,7 +136,7 @@ func (r *HttpClient) Execute() *HttpResult {
 	result := new(HttpResult)
 	defer func() {
 		if err := recover(); err != nil {
-			logs.Error("http request err: ", err)
+			logs.Error(fmt.Sprintf("url:[%s]|http request err: ", r.url), err)
 			result.Error = errors.New("http request err")
 		}
 	}()
@@ -172,8 +173,7 @@ func (r *HttpClient) Execute() *HttpResult {
 
 	result.Body = body
 	result.Status = resp.StatusCode
-	logs.Info("http status: ", resp.Status)
-	logs.Info("http respBody: ", string(body))
+	logs.Info(fmt.Sprintf("url:[%s]|http status: %s, http respBody: %s", r.url, resp.Status, string(body)))
 	return result
 }
 


### PR DESCRIPTION
resolve #4686

 

- 1、kill devopsDaemon进程的行为在 macos 下， 如果当前是由 launchd 启动的（比如mac重启之后，devopsDaemon会由launchd接管启动）, 当upgrader进程触发kill devopsDaemon时，会导致当前upgrader进程也被系统一并停掉，所以要排除macos的进程停止操作，否则会导致升级中断,  本次只是将{AgentDir}/devopsDaemon文件进行覆盖，但不做进程重启，需要手动重启。

-  2、windows 因早期daemon缺失 pid文件，在安装多个agent的机器上无法很正确的寻找到正确的进程，并且windows的启动方式较多，早期用户会使用直接双击devopsDaemon.exe文件来启动，以此来保证构建进程能够正确拉起带UI的程序，所以这块无法正确查找到进程，因此暂时也不考虑windows的devopsDaemon.exe文件升级。 windows需要手动升级:
    - windows的devopsDaemon.exe升级方式是先手动停止devopsDaemon.exe 再将{AgentDir}/tmp/devopsDaemon.exe 复制到 {AgentDir}目录下，再启动即可。