### PR TITLE
fix: dockerhost的dockerRun日志统一写入到了StartVMTask，分离开来 #5738

### DIFF
--- a/src/backend/ci/core/dockerhost/api-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/api/ServiceDockerHostResource.kt
+++ b/src/backend/ci/core/dockerhost/api-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/api/ServiceDockerHostResource.kt
@@ -47,8 +47,8 @@ import javax.ws.rs.GET
 import javax.ws.rs.POST
 import javax.ws.rs.Path
 import javax.ws.rs.PathParam
-import javax.ws.rs.QueryParam
 import javax.ws.rs.Produces
+import javax.ws.rs.QueryParam
 import javax.ws.rs.core.Context
 import javax.ws.rs.core.MediaType
 
@@ -129,6 +129,9 @@ interface ServiceDockerHostResource {
         @ApiParam(value = "buildId", required = true)
         @PathParam("buildId")
         buildId: String,
+        @ApiParam("插件ID", required = false)
+        @QueryParam("taskId")
+        pipelineTaskId: String?,
         @ApiParam("镜像名称", required = true)
         dockerRunParam: DockerRunParam,
         @Context request: HttpServletRequest

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/resources/ServiceDockerHostResourceImpl.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/resources/ServiceDockerHostResourceImpl.kt
@@ -89,12 +89,13 @@ class ServiceDockerHostResourceImpl @Autowired constructor(
         pipelineId: String,
         vmSeqId: String,
         buildId: String,
+        pipelineTaskId: String?,
         dockerRunParam: DockerRunParam,
         request: HttpServletRequest
     ): Result<DockerRunResponse> {
         checkReq(request)
         logger.info("[$buildId]|Enter ServiceDockerHostResourceImpl.dockerRun...")
-        return Result(dockerService.dockerRun(projectId, pipelineId, vmSeqId, buildId, dockerRunParam))
+        return Result(dockerService.dockerRun(projectId, pipelineId, vmSeqId, buildId, pipelineTaskId, dockerRunParam))
     }
 
     override fun getDockerRunLogs(

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/DockerService.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/DockerService.kt
@@ -110,6 +110,7 @@ class DockerService @Autowired constructor(
         pipelineId: String,
         vmSeqId: String,
         buildId: String,
+        pipelineTaskId: String?,
         dockerRunParam: DockerRunParam
     ): DockerRunResponse {
         logger.info("$buildId|dockerRun|vmSeqId=$vmSeqId|image=${dockerRunParam.imageName}|${dockerRunParam.command}")
@@ -140,7 +141,8 @@ class DockerService @Autowired constructor(
             registryUser = dockerRunParam.registryUser,
             registryPwd = dockerRunParam.registryPwd,
             dockerRunParam = dockerRunParam,
-            qpcUniquePath = qpcUniquePath
+            qpcUniquePath = qpcUniquePath,
+            pipelineTaskId = pipelineTaskId
         )
 
         containerPullImageHandler.setNextHandler(containerCustomizedRunHandler).handlerRequest(containerHandlerContext)

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/HandlerContext.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/HandlerContext.kt
@@ -27,11 +27,16 @@
 
 package com.tencent.devops.dockerhost.services
 
+import com.tencent.devops.process.engine.common.VMUtils
+
 open class HandlerContext(
     open val projectId: String,
     open val pipelineId: String,
     open val buildId: String,
     open val vmSeqId: Int,
     open val poolNo: Int,
-    open val userName: String
-)
+    open val userName: String,
+    open val pipelineTaskId: String? = VMUtils.genStartVMTaskId(vmSeqId.toString())
+) {
+    fun taskId(): String = pipelineTaskId?.takeIf { it.isNotBlank() } ?: VMUtils.genStartVMTaskId(vmSeqId.toString())
+}

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerCustomizedRunHandler.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerCustomizedRunHandler.kt
@@ -46,7 +46,6 @@ import com.tencent.devops.dockerhost.services.generator.DockerEnvLoader
 import com.tencent.devops.dockerhost.services.generator.DockerMountLoader
 import com.tencent.devops.dockerhost.utils.CommonUtils
 import com.tencent.devops.dockerhost.utils.RandomUtil
-import com.tencent.devops.process.engine.common.VMUtils
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -88,7 +87,7 @@ class ContainerCustomizedRunHandler(
                     .withWorkingDir(dockerHostConfig.volumeWorkspace)
 
                 if (!(dockerRunParam!!.command.isEmpty() || dockerRunParam.command.equals("[]"))) {
-                    createContainerCmd.withCmd(dockerRunParam!!.command)
+                    createContainerCmd.withCmd(dockerRunParam.command)
                 }
 
                 val container = createContainerCmd.exec()
@@ -107,7 +106,7 @@ class ContainerCustomizedRunHandler(
                     buildId = buildId,
                     red = true,
                     message = "启动构建环境失败，错误信息:${er.message}",
-                    tag = VMUtils.genStartVMTaskId(vmSeqId.toString()),
+                    tag = taskId(),
                     containerHashId = containerHashId
                 )
                 if (er is NotFoundException) {
@@ -155,7 +154,7 @@ class ContainerCustomizedRunHandler(
                 throw ContainerException(
                     errorCodeEnum = ErrorCodeEnum.NO_AVAILABLE_PORT_ERROR,
                     message = "No enough port to use in dockerRun. " +
-                            "startPort: ${dockerHostConfig.dockerRunStartPort}"
+                        "startPort: ${dockerHostConfig.dockerRunStartPort}"
                 )
             }
             val tcpContainerPort: ExposedPort = ExposedPort.tcp(it)

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerHandlerContext.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerHandlerContext.kt
@@ -27,12 +27,14 @@ data class ContainerHandlerContext(
     override val buildId: String,
     override val vmSeqId: Int,
     override val poolNo: Int,
-    override val userName: String
+    override val userName: String,
+    override val pipelineTaskId: String? = null
 ) : HandlerContext(
     projectId = projectId,
     pipelineId = pipelineId,
     buildId = buildId,
     vmSeqId = vmSeqId,
     poolNo = poolNo,
-    userName = userName
+    userName = userName,
+    pipelineTaskId = pipelineTaskId
 )

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerPullImageHandler.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerPullImageHandler.kt
@@ -36,7 +36,6 @@ import com.tencent.devops.dockerhost.exception.ContainerException
 import com.tencent.devops.dockerhost.services.Handler
 import com.tencent.devops.dockerhost.services.LocalImageCache
 import com.tencent.devops.dockerhost.utils.CommonUtils
-import com.tencent.devops.process.engine.common.VMUtils
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -48,7 +47,7 @@ class ContainerPullImageHandler(
     override fun handlerRequest(handlerContext: ContainerHandlerContext) {
         with(handlerContext) {
             formatImageName = CommonUtils.normalizeImageName(originImageName)
-            val taskId = VMUtils.genStartVMTaskId(vmSeqId.toString())
+            val taskId = taskId()
 
             try {
                 LocalImageCache.saveOrUpdate(formatImageName!!)

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerRunHandler.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/container/ContainerRunHandler.kt
@@ -40,7 +40,6 @@ import com.tencent.devops.dockerhost.services.generator.DockerEnvLoader
 import com.tencent.devops.dockerhost.services.generator.DockerMountLoader
 import com.tencent.devops.dockerhost.utils.ENTRY_POINT_CMD
 import com.tencent.devops.dockerhost.utils.RandomUtil
-import com.tencent.devops.process.engine.common.VMUtils
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -86,7 +85,7 @@ class ContainerRunHandler(
                     buildId = buildId,
                     red = true,
                     message = "启动构建环境失败，错误信息:${er.message}",
-                    tag = VMUtils.genStartVMTaskId(vmSeqId.toString()),
+                    tag = taskId(),
                     containerHashId = containerHashId
                 )
                 if (er is NotFoundException) {

--- a/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/image/ImageHandlerContext.kt
+++ b/src/backend/ci/core/dockerhost/biz-dockerhost/src/main/kotlin/com/tencent/devops/dockerhost/services/image/ImageHandlerContext.kt
@@ -8,7 +8,6 @@ data class ImageHandlerContext(
     val outer: Boolean, // 是否为外部请求创建镜像
     val scanFlag: Boolean, // 镜像扫描开关
     val dockerClient: DockerClient,
-    val pipelineTaskId: String?,
     val dockerBuildParam: DockerBuildParam,
     var imageTagSet: MutableSet<String> = mutableSetOf(),
     override val projectId: String,
@@ -16,12 +15,14 @@ data class ImageHandlerContext(
     override val buildId: String,
     override val vmSeqId: Int,
     override val poolNo: Int,
-    override val userName: String
+    override val userName: String,
+    override val pipelineTaskId: String?
 ) : HandlerContext(
     projectId = projectId,
     pipelineId = pipelineId,
     buildId = buildId,
     vmSeqId = vmSeqId,
     poolNo = poolNo,
-    userName = userName
+    userName = userName,
+    pipelineTaskId = pipelineTaskId
 )


### PR DESCRIPTION
现在是使用docker run接口的时候，拉取容器等日志输出到启动容器插件里面了，目标是输出到调用docker run接口的插件的流水线日志内