### PR TITLE
feat: 远程触发兼容多集群的场景 #5779

### DIFF
--- a/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/resources/apigw/v3/ApigwBuildResourceV3Impl.kt
+++ b/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/resources/apigw/v3/ApigwBuildResourceV3Impl.kt
@@ -29,6 +29,7 @@ package com.tencent.devops.openapi.resources.apigw.v3
 import com.tencent.devops.common.api.pojo.BuildHistoryPage
 import com.tencent.devops.common.api.pojo.Result
 import com.tencent.devops.common.client.Client
+import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.common.pipeline.pojo.StageReviewRequest
 import com.tencent.devops.common.web.RestResource
 import com.tencent.devops.openapi.api.apigw.v3.ApigwBuildResourceV3
@@ -112,13 +113,14 @@ class ApigwBuildResourceV3Impl @Autowired constructor(
         buildNo: Int?
     ): Result<BuildId> {
         logger.info("$pipelineId|manualStartup|user($userId)")
-        return client.get(ServiceBuildResource::class).manualStartup(
+        return client.get(ServiceBuildResource::class).manualStartupNew(
             userId = userId,
             projectId = projectId,
             pipelineId = pipelineId,
             values = values,
             buildNo = buildNo,
-            channelCode = apiGatewayUtil.getChannelCode()
+            channelCode = apiGatewayUtil.getChannelCode(),
+            startType = StartType.SERVICE
         )
     }
 

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/api/service/ServiceBuildResource.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/api/service/ServiceBuildResource.kt
@@ -27,6 +27,7 @@
 
 package com.tencent.devops.process.api.service
 
+import com.tencent.devops.common.api.auth.AUTH_HEADER_DEVOPS_PROJECT_ID
 import com.tencent.devops.common.api.auth.AUTH_HEADER_USER_ID
 import com.tencent.devops.common.api.auth.AUTH_HEADER_USER_ID_DEFAULT_VALUE
 import com.tencent.devops.common.api.pojo.BuildHistoryPage
@@ -35,6 +36,7 @@ import com.tencent.devops.common.api.pojo.Result
 import com.tencent.devops.common.api.pojo.SimpleResult
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ChannelCode
+import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.process.pojo.StageQualityRequest
 import com.tencent.devops.common.pipeline.pojo.StageReviewRequest
 import com.tencent.devops.process.pojo.BuildBasicInfo
@@ -139,6 +141,7 @@ interface ServiceBuildResource {
         channelCode: ChannelCode
     ): Result<BuildManualStartupInfo>
 
+    @Deprecated(message = "do not use", replaceWith = ReplaceWith("@see ServiceBuildResource.manualStartupNew"))
     @ApiOperation("手动启动流水线")
     @POST
     // @Path("/projects/{projectId}/pipelines/{pipelineId}/start")
@@ -574,4 +577,30 @@ interface ServiceBuildResource {
         buildId: String,
         taskPauseExecute: BuildTaskPauseInfo
     ): Result<Boolean>
+
+    @ApiOperation("手动启动流水线")
+    @POST
+    @Path("/{pipelineId}/")
+    fun manualStartupNew(
+        @ApiParam(value = "用户ID", required = true, defaultValue = AUTH_HEADER_USER_ID_DEFAULT_VALUE)
+        @HeaderParam(AUTH_HEADER_USER_ID)
+        userId: String,
+        @ApiParam("项目ID", required = true)
+        @HeaderParam(AUTH_HEADER_DEVOPS_PROJECT_ID)
+        projectId: String,
+        @ApiParam("流水线ID", required = true)
+        @PathParam("pipelineId")
+        pipelineId: String,
+        @ApiParam("启动参数", required = true)
+        values: Map<String, String>,
+        @ApiParam("渠道号，默认为DS", required = false)
+        @QueryParam("channelCode")
+        channelCode: ChannelCode,
+        @ApiParam("手动指定构建版本参数", required = false)
+        @QueryParam("buildNo")
+        buildNo: Int? = null,
+        @ApiParam("启动类型", required = false)
+        @QueryParam("startType")
+        startType: StartType
+    ): Result<BuildId>
 }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/ServiceBuildResourceImpl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/ServiceBuildResourceImpl.kt
@@ -113,22 +113,14 @@ class ServiceBuildResourceImpl @Autowired constructor(
         channelCode: ChannelCode,
         buildNo: Int?
     ): Result<BuildId> {
-        checkUserId(userId)
-        checkParam(projectId, pipelineId)
-        return Result(
-            BuildId(
-                pipelineBuildFacadeService.buildManualStartup(
-                    userId = userId,
-                    startType = StartType.SERVICE,
-                    projectId = projectId,
-                    pipelineId = pipelineId,
-                    values = values,
-                    channelCode = channelCode,
-                    buildNo = buildNo,
-                    checkPermission = ChannelCode.isNeedAuth(channelCode),
-                    frequencyLimit = true
-                )
-            )
+        return manualStartupNew(
+            userId = userId,
+            startType = StartType.SERVICE,
+            projectId = projectId,
+            pipelineId = pipelineId,
+            values = values,
+            channelCode = channelCode,
+            buildNo = buildNo
         )
     }
 
@@ -540,6 +532,34 @@ class ServiceBuildResourceImpl @Autowired constructor(
                 element = taskPauseExecute.element,
                 stageId = taskPauseExecute.stageId,
                 containerId = taskPauseExecute.containerId
+            )
+        )
+    }
+
+    override fun manualStartupNew(
+        userId: String,
+        projectId: String,
+        pipelineId: String,
+        values: Map<String, String>,
+        channelCode: ChannelCode,
+        buildNo: Int?,
+        startType: StartType
+    ): Result<BuildId> {
+        checkUserId(userId)
+        checkParam(projectId, pipelineId)
+        return Result(
+            BuildId(
+                pipelineBuildFacadeService.buildManualStartup(
+                    userId = userId,
+                    startType = startType,
+                    projectId = projectId,
+                    pipelineId = pipelineId,
+                    values = values,
+                    channelCode = channelCode,
+                    buildNo = buildNo,
+                    checkPermission = ChannelCode.isNeedAuth(channelCode),
+                    frequencyLimit = true
+                )
             )
         )
     }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineRemoteAuthService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineRemoteAuthService.kt
@@ -95,6 +95,8 @@ class PipelineRemoteAuthService @Autowired constructor(
         }
 
         logger.info("Start the pipeline remotely of $userId ${pipeline.pipelineId} of project ${pipeline.projectId}")
+        // #5779 为兼容多集群的场景。流水线的启动需要路由到项目对应的集群。此处携带X-DEVOPS-PROJECT-ID头重新请求网关,由网关路由到项目对应的集群
+        // 因原ServiceBuildResource内的manualStartup接口未满足ProjectId在HEAD内的标准。故重新定义一个标准的接口
         return client.getGateway(ServiceBuildResource::class).manualStartupNew(
                 userId = userId!!,
                 projectId = pipeline.projectId,
@@ -104,20 +106,6 @@ class PipelineRemoteAuthService @Autowired constructor(
                 startType = StartType.REMOTE,
                 buildNo = null
             ).data!!
-//        return BuildId(
-//            pipelineBuildFacadeService.buildManualStartup(
-//                userId = userId!!,
-//                startType = StartType.REMOTE,
-//                projectId = pipeline.projectId,
-//                pipelineId = pipeline.pipelineId,
-//                values = values,
-//                channelCode = ChannelCode.BS,
-//                checkPermission = true,
-//                isMobile = false,
-//                startByMessage = "m-$auth",
-//                frequencyLimit = true
-//            )
-//        )
     }
 
     companion object {

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineRemoteAuthService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineRemoteAuthService.kt
@@ -29,11 +29,13 @@ package com.tencent.devops.process.service
 
 import com.tencent.devops.common.api.exception.OperationException
 import com.tencent.devops.common.api.util.UUIDUtil
+import com.tencent.devops.common.client.Client
 import com.tencent.devops.common.pipeline.enums.ChannelCode
 import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.common.redis.RedisLock
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.model.process.tables.records.TPipelineRemoteAuthRecord
+import com.tencent.devops.process.api.service.ServiceBuildResource
 import com.tencent.devops.process.dao.PipelineRemoteAuthDao
 import com.tencent.devops.process.engine.service.PipelineRepositoryService
 import com.tencent.devops.process.pojo.BuildId
@@ -51,7 +53,8 @@ class PipelineRemoteAuthService @Autowired constructor(
     private val pipelineRemoteAuthDao: PipelineRemoteAuthDao,
     private val pipelineBuildFacadeService: PipelineBuildFacadeService,
     private val pipelineReportService: PipelineRepositoryService,
-    private val redisOperation: RedisOperation
+    private val redisOperation: RedisOperation,
+    private val client: Client
 ) {
 
     fun generateAuth(pipelineId: String, projectId: String, userId: String): PipelineRemoteToken {
@@ -92,20 +95,29 @@ class PipelineRemoteAuthService @Autowired constructor(
         }
 
         logger.info("Start the pipeline remotely of $userId ${pipeline.pipelineId} of project ${pipeline.projectId}")
-        return BuildId(
-            pipelineBuildFacadeService.buildManualStartup(
+        return client.get(ServiceBuildResource::class).manualStartupNew(
                 userId = userId!!,
-                startType = StartType.REMOTE,
                 projectId = pipeline.projectId,
                 pipelineId = pipeline.pipelineId,
                 values = values,
                 channelCode = ChannelCode.BS,
-                checkPermission = true,
-                isMobile = false,
-                startByMessage = "m-$auth",
-                frequencyLimit = true
-            )
-        )
+                startType = StartType.REMOTE,
+                buildNo = null
+            ).data!!
+//        return BuildId(
+//            pipelineBuildFacadeService.buildManualStartup(
+//                userId = userId!!,
+//                startType = StartType.REMOTE,
+//                projectId = pipeline.projectId,
+//                pipelineId = pipeline.pipelineId,
+//                values = values,
+//                channelCode = ChannelCode.BS,
+//                checkPermission = true,
+//                isMobile = false,
+//                startByMessage = "m-$auth",
+//                frequencyLimit = true
+//            )
+//        )
     }
 
     companion object {

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineRemoteAuthService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineRemoteAuthService.kt
@@ -95,7 +95,7 @@ class PipelineRemoteAuthService @Autowired constructor(
         }
 
         logger.info("Start the pipeline remotely of $userId ${pipeline.pipelineId} of project ${pipeline.projectId}")
-        return client.get(ServiceBuildResource::class).manualStartupNew(
+        return client.getGateway(ServiceBuildResource::class).manualStartupNew(
                 userId = userId!!,
                 projectId = pipeline.projectId,
                 pipelineId = pipeline.pipelineId,

--- a/src/backend/ci/core/store/biz-store-image/src/main/kotlin/com/tencent/devops/store/service/image/ImageReleaseService.kt
+++ b/src/backend/ci/core/store/biz-store-image/src/main/kotlin/com/tencent/devops/store/service/image/ImageReleaseService.kt
@@ -39,6 +39,7 @@ import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.api.util.UUIDUtil
 import com.tencent.devops.common.client.Client
 import com.tencent.devops.common.pipeline.enums.ChannelCode
+import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.common.pipeline.pojo.CheckImageInitPipelineReq
 import com.tencent.devops.common.pipeline.type.BuildType
 import com.tencent.devops.common.pipeline.type.docker.ImageType
@@ -656,12 +657,13 @@ abstract class ImageReleaseService {
             if (null != password) {
                 startParams["registryPwd"] = password
             }
-            val buildIdObj = client.get(ServiceBuildResource::class).manualStartup(
+            val buildIdObj = client.get(ServiceBuildResource::class).manualStartupNew(
                 userId = userId,
                 projectId = projectCode!!,
                 pipelineId = imagePipelineRelRecord.pipelineId,
                 values = startParams,
-                channelCode = ChannelCode.AM
+                channelCode = ChannelCode.AM,
+                startType = StartType.SERVICE
             ).data
             logger.info("the buildIdObj is:$buildIdObj")
             if (null != buildIdObj) {


### PR DESCRIPTION
1. 定义新接口ServiceBuildResource.manualStartupNew。 projectId按标准在HEAD内
2. 远程触发auth转为为pipeline后，获取到project通过网关转发一次。 通过网关路由到项目对应的集群。
3. 现有的ServiceBuildResource.manualStartup请求逻辑调整为ServiceBuildResource.manualStartupNew