### PR TITLE
bug: bk-ubt-tool在错误处理时，和ue原始逻辑有差异

### DIFF
--- a/src/backend/booster/bk_dist/ubttool/command/process.go
+++ b/src/backend/booster/bk_dist/ubttool/command/process.go
@@ -117,10 +117,11 @@ func setLogLevel(level string) {
 
 func initialLogDir(dir string) {
 	blog.InitLogs(conf.LogConfig{
-		LogDir:       dir,
-		LogMaxNum:    10,
-		LogMaxSize:   500,
-		AlsoToStdErr: false,
+		LogDir:          dir,
+		LogMaxNum:       10,
+		LogMaxSize:      500,
+		AlsoToStdErr:    false,
+		StdErrThreshold: "3", //fatalLog
 	})
 }
 

--- a/src/backend/booster/bk_dist/ubttool/common/types.go
+++ b/src/backend/booster/bk_dist/ubttool/common/types.go
@@ -38,6 +38,7 @@ type Actionresult struct {
 	Succeed   bool
 	Outputmsg string
 	Errormsg  string
+	Exitcode  int
 }
 
 func uniqueAndCheck(strlist []string, allindex map[string]bool) []string {

--- a/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
@@ -175,7 +175,7 @@ func (h *UBTTool) executeActions() error {
 		select {
 		case r := <-h.actionchan:
 			blog.Infof("UBTTool: got action result:%+v", r)
-			h.onActionFinished(r.Index)
+			h.onActionFinished(r.Index, r.Exitcode)
 			if h.finished {
 				blog.Infof("UBTTool: all actions finished")
 				return nil
@@ -242,7 +242,7 @@ func (h *UBTTool) executeOneAction(action common.Action, actionchan chan common.
 	fullargs := []string{action.Cmd}
 	args, _ := shlex.Split(replaceWithNextExclude(action.Arg, '\\', "\\\\", []byte{'"'}))
 	fullargs = append(fullargs, args...)
-	_, err := h.executor.Run(fullargs, action.Workdir)
+	exitcode, err := h.executor.Run(fullargs, action.Workdir)
 
 	r := common.Actionresult{
 		Index:     action.Index,
@@ -250,6 +250,7 @@ func (h *UBTTool) executeOneAction(action common.Action, actionchan chan common.
 		Succeed:   err == nil,
 		Outputmsg: "",
 		Errormsg:  "",
+		Exitcode:  exitcode,
 	}
 
 	actionchan <- r
@@ -279,8 +280,8 @@ func (h *UBTTool) getReadyActions() error {
 }
 
 // update all actions and ready actions
-func (h *UBTTool) onActionFinished(index string) error {
-	blog.Infof("UBTTool: action %s finished", index)
+func (h *UBTTool) onActionFinished(index string, exitcode int) error {
+	blog.Infof("UBTTool: action %s finished with exitcode %d", index, exitcode)
 
 	h.finishednumberlock.Lock()
 	h.finishednumber++
@@ -309,30 +310,35 @@ func (h *UBTTool) onActionFinished(index string) error {
 		}
 	}
 
-	// update all action array
+	// update status in allactions
 	for i, v := range h.allactions {
 		// update status
 		if v.Index == index {
 			h.allactions[i].Finished = true
-			continue
+			break
 		}
+	}
 
-		if v.Finished {
-			continue
-		}
-
-		// update depend
-		for i1, v1 := range v.Dep {
-			if v1 == index {
-				h.allactions[i].Dep = remove(h.allactions[i].Dep, i1)
-				break
+	// update depend in allactions if current action succeed
+	if exitcode == 0 {
+		for i, v := range h.allactions {
+			if v.Finished {
+				continue
 			}
-		}
 
-		// copy to ready if no depent
-		if !v.Running && !v.Finished && len(h.allactions[i].Dep) == 0 {
-			h.readyactions = append(h.readyactions, v)
-			h.allactions[i].Running = true
+			// update depend
+			for i1, v1 := range v.Dep {
+				if v1 == index {
+					h.allactions[i].Dep = remove(h.allactions[i].Dep, i1)
+					break
+				}
+			}
+
+			// copy to ready if no depent
+			if !v.Running && !v.Finished && len(h.allactions[i].Dep) == 0 {
+				h.readyactions = append(h.readyactions, v)
+				h.allactions[i].Running = true
+			}
 		}
 	}
 


### PR DESCRIPTION
优化 bk-ubt-tool 处理编译错误时的逻辑，当任务有错误发生时，后续依赖该任务的其它任务不会再执行