### PR TITLE
feat:优化bk-dist-worker的错误日志，增加是否删除临时文件的配置

### DIFF
--- a/src/backend/booster/bk_dist/worker/config/config.go
+++ b/src/backend/booster/bk_dist/worker/config/config.go
@@ -44,6 +44,7 @@ type WorkerConfig struct {
 	DefaultWorkDir string `json:"default_work_dir" value:"./default_work_dir" usage:"default work dir to execute scmd"`
 	// CommonFileTypes []string `json:"need_clean_files" value:".pch,.gch" usage:"file types which need to save as common files"`
 	CmdReplaceRules []dcConfig.CmdReplaceRule `json:"cmd_replace_rules" value:"" usage:"rules to replace input cmd"`
+	CleanTempFiles  bool                      `json:"clean_temp_files" value:"true" usage:"enable temp files clean when task finished"`
 }
 
 // NewConfig : return config of server

--- a/src/backend/booster/bk_dist/worker/pkg/cmd_handler/handler4dispatchtask.go
+++ b/src/backend/booster/bk_dist/worker/pkg/cmd_handler/handler4dispatchtask.go
@@ -238,6 +238,7 @@ func (h *Handle4DispatchReq) dealOneCommand(onecmd *dcProtocol.PBCommand,
 			exefullpath,
 			strings.Join(params, " "),
 			(end64-start64)/1000/1000/1000,
+			err,
 			outputMsg,
 			errorMsg)
 	} else {
@@ -245,6 +246,7 @@ func (h *Handle4DispatchReq) dealOneCommand(onecmd *dcProtocol.PBCommand,
 			exefullpath,
 			strings.Join(params, " "),
 			(end64-start64)/1000/1000/1000,
+			err,
 			outputMsg,
 			errorMsg)
 	}

--- a/src/backend/booster/bk_dist/worker/pkg/cmd_handler/handler4dispatchtask.go
+++ b/src/backend/booster/bk_dist/worker/pkg/cmd_handler/handler4dispatchtask.go
@@ -234,9 +234,19 @@ func (h *Handle4DispatchReq) dealOneCommand(onecmd *dcProtocol.PBCommand,
 	end64 := time.Now().UnixNano()
 
 	if err != nil {
-		blog.Errorf("failed to execute command for error: %v,output:[%s],errmsg:[%s]", err, outputMsg, errorMsg)
-		// in this condition, we should return detail error message
-		// return nil, err
+		blog.Errorf("failed to execute command[%s %s] after %d seconds for error: %v,output:[%s],errmsg:[%s]",
+			exefullpath,
+			strings.Join(params, " "),
+			(end64-start64)/1000/1000/1000,
+			outputMsg,
+			errorMsg)
+	} else {
+		blog.Infof("succeed to execute command[%s %s] after %d seconds for error: %v,output:[%s],errmsg:[%s]",
+			exefullpath,
+			strings.Join(params, " "),
+			(end64-start64)/1000/1000/1000,
+			outputMsg,
+			errorMsg)
 	}
 
 	retcode32 := int32(retcode)

--- a/src/backend/booster/bk_dist/worker/pkg/manager/manager.go
+++ b/src/backend/booster/bk_dist/worker/pkg/manager/manager.go
@@ -513,9 +513,11 @@ func (o *tcpManager) dealBufferedCmd(cmd *buffedcmd) error {
 
 		blog.Infof("ready to close tcp connection after deal this cmd")
 		_ = cmd.client.Close()
-		// remove basedir here
-		_ = os.RemoveAll(cmd.basedir)
-		blog.Infof("deal cmd out, removed base dir:%s", cmd.basedir)
+		if o.conf.CleanTempFiles {
+			// remove basedir here
+			_ = os.RemoveAll(cmd.basedir)
+			blog.Infof("deal cmd out, removed base dir:%s", cmd.basedir)
+		}
 
 		debug.FreeOSMemory() // free memory anyway
 	}()

--- a/src/backend/booster/server/pkg/resource/direct/agent/pkg/manager/manager.go
+++ b/src/backend/booster/server/pkg/resource/direct/agent/pkg/manager/manager.go
@@ -733,6 +733,7 @@ func (o *processManager) reportResource() error {
 		for _, uri := range uriList {
 			blog.Debugf("report resource: report to %s, data: %s", uri, (string)(data))
 			if _, _, err = o.post(uri, o.getHeader(""), data); err != nil {
+				blog.Warnf("failed to report resource to server %s with data %s, error:%v", uri, (string)(data), err)
 				continue
 			}
 


### PR DESCRIPTION
改动点（针对bk-dist-worker）：
1. 增加一个配置项，用于决定是否删除临时文件，默认是需要删除，在某些调试环境下，可以用该配置项保留临时文件，方便调试
2. 增加了几个错误日志，方便定位问题