### PR TITLE
feat: 流水线长度限制支持255以内动态配置 #6229

### DIFF
--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/config/PipelineCommonSettingConfig.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/config/PipelineCommonSettingConfig.kt
@@ -38,4 +38,10 @@ class PipelineCommonSettingConfig {
 
     @Value("\${pipeline.setting.common.stage.maxStageNum:20}")
     val maxStageNum: Int = 20
+
+    @Value("\${pipeline.setting.common.maxPipelineNameSize:20}")
+    val maxPipelineNameSize: Int = 255
+
+    @Value("\${pipeline.setting.common.maxPipelineDescSize:20}")
+    val maxPipelineDescSize: Int = 255
 }

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/config/PipelineCommonSettingConfig.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/config/PipelineCommonSettingConfig.kt
@@ -39,9 +39,9 @@ class PipelineCommonSettingConfig {
     @Value("\${pipeline.setting.common.stage.maxStageNum:20}")
     val maxStageNum: Int = 20
 
-    @Value("\${pipeline.setting.common.maxPipelineNameSize:20}")
+    @Value("\${pipeline.setting.common.maxPipelineNameSize:255}")
     val maxPipelineNameSize: Int = 255
 
-    @Value("\${pipeline.setting.common.maxPipelineDescSize:20}")
+    @Value("\${pipeline.setting.common.maxPipelineDescSize:255}")
     val maxPipelineDescSize: Int = 255
 }

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/extend/DefaultModelCheckPlugin.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/extend/DefaultModelCheckPlugin.kt
@@ -74,8 +74,14 @@ open class DefaultModelCheckPlugin constructor(
 
     override fun checkModelIntegrity(model: Model, projectId: String?) {
         // 检查流水线名称
-        PipelineUtils.checkPipelineName(model.name)
-        PipelineUtils.checkPipelineDescLength(model.desc)
+        PipelineUtils.checkPipelineName(
+            name = model.name,
+            maxPipelineNameSize = pipelineCommonSettingConfig.maxPipelineNameSize
+        )
+        PipelineUtils.checkPipelineDescLength(
+            desc = model.desc,
+            maxPipelineNameSize = pipelineCommonSettingConfig.maxPipelineDescSize
+        )
         // 检查流水线model是否过大
         val modelSize = JsonUtil.toJson(model).length
         if (modelSize > pipelineCommonSettingConfig.maxModelSize.toLong()) {

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/utils/PipelineUtils.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/utils/PipelineUtils.kt
@@ -46,11 +46,9 @@ object PipelineUtils {
     private val logger = LoggerFactory.getLogger(PipelineUtils::class.java)
 
     private const val ENGLISH_NAME_PATTERN = "[A-Za-z_][A-Za-z_0-9]*"
-    private const val MAX_DESC_LENGTH = 100
-    private const val MAX_NAME_LENGTH = 64
 
-    fun checkPipelineName(name: String) {
-        if (name.toCharArray().size > MAX_NAME_LENGTH) {
+    fun checkPipelineName(name: String, maxPipelineNameSize: Int) {
+        if (name.toCharArray().size > maxPipelineNameSize) {
             throw ErrorCodeException(
                 errorCode = ProcessMessageCode.ERROR_PIPELINE_NAME_TOO_LONG,
                 defaultMessage = "Pipeline's name is too long"
@@ -69,8 +67,8 @@ object PipelineUtils {
         }
     }
 
-    fun checkPipelineDescLength(desc: String?) {
-        if (desc != null && desc.toCharArray().size > MAX_DESC_LENGTH) {
+    fun checkPipelineDescLength(desc: String?, maxPipelineNameSize: Int) {
+        if (desc != null && desc.toCharArray().size > maxPipelineNameSize) {
             throw ErrorCodeException(
                 errorCode = ProcessMessageCode.ERROR_PIPELINE_DESC_TOO_LONG,
                 defaultMessage = "Pipeline's desc is too long"

--- a/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/extend/DefaultModelCheckPluginTest.kt
+++ b/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/extend/DefaultModelCheckPluginTest.kt
@@ -154,6 +154,8 @@ class DefaultModelCheckPluginTest : TestBase() {
         )
         whenever(pipelineCommonSettingConfig.maxModelSize).thenReturn(16777215)
         whenever(pipelineCommonSettingConfig.maxStageNum).thenReturn(20)
+        whenever(pipelineCommonSettingConfig.maxPipelineNameSize).thenReturn(255)
+        whenever(pipelineCommonSettingConfig.maxPipelineDescSize).thenReturn(255)
         whenever(stageCommonSettingConfig.maxJobNum).thenReturn(20)
         whenever(jobCommonSettingConfig.maxTaskNum).thenReturn(20)
         whenever(taskCommonSettingConfig.maxInputNum).thenReturn(50)

--- a/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/utils/PipelineUtilsTest.kt
+++ b/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/utils/PipelineUtilsTest.kt
@@ -38,13 +38,13 @@ class PipelineUtilsTest {
     @Test
     fun checkPipelineNameLength() {
         val name = "1234567890123456789012345678901234567890123456789012345678901234"
-        PipelineUtils.checkPipelineName(name)
+        PipelineUtils.checkPipelineName(name, 64)
     }
 
     @Test(expected = ErrorCodeException::class)
     fun checkPipelineNameTooLength() {
         val name = "12345678901234567890123456789012345678901234567890123456789012345" // exceed 64 char
-        PipelineUtils.checkPipelineName(name)
+        PipelineUtils.checkPipelineName(name, 64)
     }
 
     @Test
@@ -72,16 +72,16 @@ class PipelineUtilsTest {
     @Test
     fun checkPipelineDescLength() {
         var desc: String? = null
-        PipelineUtils.checkPipelineDescLength(desc)
+        PipelineUtils.checkPipelineDescLength(desc, 100)
         desc = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
-        PipelineUtils.checkPipelineDescLength(desc)
+        PipelineUtils.checkPipelineDescLength(desc, 100)
     }
 
     @Test(expected = ErrorCodeException::class)
     fun checkPipelineDescLength101() {
         val desc =
             "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
-        PipelineUtils.checkPipelineDescLength(desc)
+        PipelineUtils.checkPipelineDescLength(desc, 100)
     }
 
     private fun make(id: String): BuildFormProperty {

--- a/support-files/templates/#etc#ci#application-process.yml
+++ b/support-files/templates/#etc#ci#application-process.yml
@@ -45,6 +45,8 @@ pipeline:
     common:
       maxModelSize: 16777215
       maxStageNum: 20
+      maxPipelineNameSize: 255
+      maxPipelineDescSize: 255
       stage:
         maxJobNum: 20
         job:


### PR DESCRIPTION
流水线长度，描述最大长度可配置化。 默认255