### PR TITLE
feat: 优化agent启动构建时避免写死Bash shell #5304

### DIFF
--- a/src/agent/src/pkg/config/version.go
+++ b/src/agent/src/pkg/config/version.go
@@ -27,4 +27,4 @@
 
 package config
 
-const AgentVersion = "v1.8.0"
+const AgentVersion = "v1.8.1"

--- a/src/agent/src/pkg/job/build.go
+++ b/src/agent/src/pkg/job/build.go
@@ -244,7 +244,6 @@ func writeStartBuildAgentScript(buildInfo *api.ThirdPartyBuildInfo) (string, err
 	agentLogPrefix := fmt.Sprintf("%s_%s_agent", buildInfo.BuildId, buildInfo.VmSeqId)
 	lines := []string{
 		"#!" + getCurrentShell(),
-		"source /etc/profile",
 		fmt.Sprintf("cd %s", systemutil.GetWorkDir()),
 		fmt.Sprintf("%s -Ddevops.slave.agent.start.file=%s -Ddevops.slave.agent.prepare.start.file=%s -Dbuild.type=AGENT -Ddevops.slave.agent.role=devops.slave.agent.role.slave -DAGENT_LOG_PREFIX=%s -jar %s %s",
 			config.GetJava(), scriptFile, prepareScriptFile, agentLogPrefix, config.BuildAgentJarPath(), getEncodedBuildInfo(buildInfo)),


### PR DESCRIPTION
macos 下 path会导致重组引起顺序问题， 移除多余的 /etc/profile 指令
see
https://www.softec.lu/site/DevelopersCorner/MasteringThePathHelper
