### PR TITLE
蓝盾task执行超时场景下，BK_CI_BUILD_FAIL_TASKS变量为空 #5249

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
@@ -640,19 +640,13 @@ class EngineVMBuildService @Autowired(required = false) constructor(
                 ) -> {
                     BuildStatus.RETRY
                 }
-                result.errorCode == ErrorCode.USER_TASK_OUTTIME_LIMIT -> {
-                    pipelineTaskService.createFailTaskVar(
-                        buildId = buildId, projectId = buildInfo.projectId,
-                        pipelineId = buildInfo.pipelineId, taskId = result.taskId
-                    )
-                    BuildStatus.EXEC_TIMEOUT
-                }
                 else -> { // 记录错误插件信息
                     pipelineTaskService.createFailTaskVar(
                         buildId = buildId, projectId = buildInfo.projectId,
                         pipelineId = buildInfo.pipelineId, taskId = result.taskId
                     )
-                    BuildStatus.FAILED
+                    if (result.errorCode == ErrorCode.USER_TASK_OUTTIME_LIMIT) BuildStatus.EXEC_TIMEOUT
+                    else BuildStatus.FAILED
                 }
             }
         }

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/vmbuild/EngineVMBuildService.kt
@@ -641,6 +641,10 @@ class EngineVMBuildService @Autowired(required = false) constructor(
                     BuildStatus.RETRY
                 }
                 result.errorCode == ErrorCode.USER_TASK_OUTTIME_LIMIT -> {
+                    pipelineTaskService.createFailTaskVar(
+                        buildId = buildId, projectId = buildInfo.projectId,
+                        pipelineId = buildInfo.pipelineId, taskId = result.taskId
+                    )
                     BuildStatus.EXEC_TIMEOUT
                 }
                 else -> { // 记录错误插件信息


### PR DESCRIPTION
蓝盾task执行超时场景下，BK_CI_BUILD_FAIL_TASKS变量为空 #5249