### PR TITLE
feat: 插件暂停继续需校验关机状态 #6317

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/pojo/event/PipelineTaskPauseEvent.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/pojo/event/PipelineTaskPauseEvent.kt
@@ -43,5 +43,6 @@ data class PipelineTaskPauseEvent(
     val buildId: String,
     val taskId: String,
     val containerId: String,
-    val stageId: String
+    val stageId: String,
+    var retryCount: Int = 0
 ) : IPipelineEvent(actionType, source, projectId, pipelineId, userId, delayMills)

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
@@ -36,12 +36,12 @@ import com.tencent.devops.common.log.utils.BuildLogPrinter
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.pojo.element.Element
 import com.tencent.devops.common.redis.RedisOperation
+import com.tencent.devops.process.engine.common.BS_ATOM_STATUS_REFRESH_DELAY_MILLS
 import com.tencent.devops.process.engine.common.BS_MANUAL_STOP_PAUSE_ATOM
 import com.tencent.devops.process.engine.common.VMUtils
 import com.tencent.devops.process.engine.control.lock.BuildIdLock
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask
 import com.tencent.devops.process.engine.pojo.event.PipelineTaskPauseEvent
-import com.tencent.devops.process.engine.service.PipelineRuntimeService
 import com.tencent.devops.process.engine.service.detail.TaskBuildDetailService
 import com.tencent.devops.process.engine.pojo.event.PipelineBuildContainerEvent
 import com.tencent.devops.process.engine.service.PipelineContainerService
@@ -61,7 +61,6 @@ class PipelineTaskPauseListener @Autowired constructor(
     private val taskBuildDetailService: TaskBuildDetailService,
     private val pipelineTaskService: PipelineTaskService,
     private val pipelineContainerService: PipelineContainerService,
-    private val pipelineRuntimeService: PipelineRuntimeService,
     private val pipelineTaskPauseService: PipelineTaskPauseService,
     private val buildVariableService: BuildVariableService,
     private val dslContext: DSLContext,
@@ -73,8 +72,21 @@ class PipelineTaskPauseListener @Autowired constructor(
         val redisLock = BuildIdLock(redisOperation = redisOperation, buildId = event.buildId)
         try {
             redisLock.lock()
+            // feat: 插件暂停继续需校验关机状态 #6317:没有关机，丢入延迟队列轮询
+            if (!checkStopVm(taskRecord!!)) {
+                // 重试次数超过阈值, 直接失败
+                if (event.retryCount > RETRY_MAX_COUNT) {
+                    logger.warn("Pause Continue retryCount fail. ${taskRecord.buildId}|${taskRecord.taskName}")
+                    return
+                }
+                with(event) {
+                    delayEvent(taskRecord)
+                }
+                return
+            }
+
             if (event.actionType == ActionType.REFRESH) {
-                taskContinue(task = taskRecord!!, userId = event.userId)
+                taskContinue(taskRecord!!, event.userId)
             } else if (event.actionType == ActionType.END) {
                 taskCancel(task = taskRecord!!, userId = event.userId)
             }
@@ -244,8 +256,42 @@ class PipelineTaskPauseListener @Autowired constructor(
         )
     }
 
+    private fun checkStopVm(task: PipelineBuildTask): Boolean {
+        val projectId = task.projectId
+        val buildId = task.buildId
+        val jobId = task.containerId
+        // 查找job所属job对应的关机插件是否完成
+        val stopVmInfo = pipelineTaskService.getBuildTask(
+            projectId = projectId,
+            buildId = buildId,
+            taskId = VMUtils.genStopVMTaskId(jobId.toInt())
+        ) ?: return false
+        if (stopVmInfo.status.isFinish()) {
+            return true
+        }
+        logger.warn("PauseListener checkStopVm $projectId|$buildId|$jobId|${stopVmInfo.status}")
+        return false
+    }
+
+    private fun PipelineTaskPauseEvent.delayEvent(task: PipelineBuildTask) {
+        // 默认延迟3秒再继续丢入队列
+        val loopDelayMills =
+            if (task.taskParams[BS_ATOM_STATUS_REFRESH_DELAY_MILLS] != null) {
+                task.taskParams[BS_ATOM_STATUS_REFRESH_DELAY_MILLS].toString().trim().toInt()
+            } else {
+                DELAY_SIZE
+            }
+        // 重试延迟时间随着次数添加延迟时间
+        this.delayMills += loopDelayMills
+        this.retryCount += 1
+        logger.info("taskContinue delay${this.delayMills}. ${this.buildId}| ${this.containerId}| ${task.taskName}")
+        pipelineEventDispatcher.dispatch(this)
+    }
+
     companion object {
         private val logger = LoggerFactory.getLogger(PipelineTaskPauseListener::class.java)
         private const val VALUE_KEY = "BK_CI_OPERATOR"
+        private const val DELAY_SIZE = 3000
+        private const val RETRY_MAX_COUNT = 5
     }
 }

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/listener/run/PipelineTaskPauseListener.kt
@@ -267,7 +267,7 @@ class PipelineTaskPauseListener @Autowired constructor(
             containerSeqId = jobId
         )
         jobTaskInfos.forEach {
-            if (it.taskId.startsWith(VMUtils.getStopVmLabel()) ) {
+            if (it.taskId.startsWith(VMUtils.getStopVmLabel())) {
                 if (it.status.isFinish()) {
                     logger.info("PauseListener checkStopVm $projectId|$buildId|$jobId| success")
                     return true


### PR DESCRIPTION
PipelineTaskPauseEvent 事件处理时，优先判断当前job下的stopVm任务是否有完成。若未完成丢入延迟队列。
每次丢入延迟队列追加3秒。 最多5次。