### PR TITLE
bug: git事件触发首次选择插件，commit push hook事件展示同时锁定问题 issue #6341

### DIFF
--- a/src/frontend/devops-pipeline/src/components/AtomPropertyPanel/CodeGitWebHookTrigger.vue
+++ b/src/frontend/devops-pipeline/src/components/AtomPropertyPanel/CodeGitWebHookTrigger.vue
@@ -25,11 +25,13 @@
             'element.enableCheck': {
                 // git事件触发选中commit check ， 同时锁定提交才显示
                 handler (newVal) {
-                    if (newVal) {
-                        this.atomPropsModel.block.hidden = false
-                    } else {
-                        this.atomPropsModel.block.hidden = true
-                        this.handleUpdateElement('block', false)
+                    if (this.element.eventType === 'MERGE_REQUEST') {
+                        if (newVal) {
+                            this.atomPropsModel.block.hidden = false
+                        } else {
+                            this.atomPropsModel.block.hidden = true
+                            this.handleUpdateElement('block', false)
+                        }
                     }
                 },
                 immediate: true,
@@ -38,6 +40,7 @@
         },
         created () {
             if (this.element.eventType === 'MERGE_REQUEST') {
+                this.atomPropsModel.block.hidden = false
                 this.atomPropsModel.webhookQueue.hidden = false
             } else {
                 this.atomPropsModel.block.hidden = true


### PR DESCRIPTION
bug: git事件触发首次选择插件，commit push hook事件展示同时锁定问题 issue #6341