### PR TITLE
fix: openapi Element 的动态子类加载不全 #6387

### DIFF
--- a/src/backend/ci/core/process/api-process/build.gradle.kts
+++ b/src/backend/ci/core/process/api-process/build.gradle.kts
@@ -28,8 +28,8 @@
 dependencies {
     api(project(":core:common:common-api"))
     api(project(":core:common:common-event"))
-    api(project(":core:common:common-event"))
-    api(project(":core:common:common-event"))
+    api(project(":core:common:common-pipeline"))
+    api(project(":core:common:common-archive"))
     api(project(":core:common:common-auth:common-auth-api"))
     api(project(":core:store:api-store"))
     api(project(":core:store:api-store-image"))


### PR DESCRIPTION
将依赖放到api-process,保证可以被依赖加载到 fix #6387