### PR TITLE
feat:lessen jobs dispatched to remote,issue: #6456

### DIFF
--- a/src/backend/booster/server/pkg/engine/disttask/task.go
+++ b/src/backend/booster/server/pkg/engine/disttask/task.go
@@ -50,7 +50,7 @@ func (dt *distTask) WorkerList() []string {
 		if dt.Operator.RequestProcessPerUnit > 0 {
 			jobs = float64(dt.Operator.RequestProcessPerUnit)
 		}
-		workers = append(workers, fmt.Sprintf("%s:%d/%d", v.IP, v.Port, int(jobs*1.3)))
+		workers = append(workers, fmt.Sprintf("%s:%d/%d", v.IP, v.Port, int(jobs*1.1)))
 	}
 
 	return workers


### PR DESCRIPTION
调小分发到远端worker的job数，避免job长时间在worker的队列中，等待超时

减少队列中的任务，有助于更均匀的分配job到远端