### PR TITLE
fix: agent build_tmp 目录权限问题 #6545

### DIFF
--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/WorkRunner.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/WorkRunner.kt
@@ -65,8 +65,6 @@ object WorkRunner {
 
             ThirdPartyAgentBuildInfoUtils.setBuildInfo(buildInfo)
 
-            LoggerService.start()
-
             Runner.run(object : WorkspaceInterface {
                 val workspace = buildInfo.workspace
                 override fun getWorkspaceAndLogDir(

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt
@@ -73,14 +73,13 @@ object Runner {
         val buildVariables = EngineService.setStarted()
         var failed = false
         try {
-            // 上报agent启动给quota
-            QuotaService.addRunningAgent(buildVariables)
-
             BuildEnv.setBuildId(buildVariables.buildId)
 
             workspacePathFile = prepareWorkspace(buildVariables, workspaceInterface)
 
             try {
+                // 上报agent启动给quota
+                QuotaService.addRunningAgent(buildVariables)
                 // 开始轮询
                 failed = loopPickup(workspacePathFile, buildVariables)
             } catch (ignore: Throwable) {

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
@@ -168,8 +168,24 @@ object LoggerService {
     }
 
     fun start() {
-        logger.info("Start the log service")
-        future = executorService.submit(loggerThread)
+        if (future == null) {
+            logger.info("Start the log service")
+            future = executorService.submit(loggerThread)
+            addStopHook(loggerService = this)
+        }
+    }
+
+    /**
+     *  防止进程关闭时忘记停止，导致被hold住
+     */
+    private fun addStopHook(loggerService: LoggerService) {
+        try {
+            Runtime.getRuntime().addShutdownHook(object : Thread() {
+                override fun run() = loggerService.stop()
+            })
+        } catch (t: Throwable) {
+            logger.warn("Fail to add shutdown hook", t)
+        }
     }
 
     fun flush(): Int {


### PR DESCRIPTION
搭车fix：LoggerService 提前启动，在未进入构建前失败会导致未完成stop方法，引起构建进程被hold住

修复前复现：

将构建机的并发设置为1

启动一个构建，在准备构建环境那一时刻，立即点“取消”，

tail -f devopsAgent.log 
会有：
parallel task count exceed , wait job done, ParallelTaskCount config: 1, instance count: 1

以及newHeartbeat 信息会包含刚才存在的构建，说明未被释放。

<img width="1934" alt="image" src="https://user-images.githubusercontent.com/16686129/164730288-6070ee81-11f8-4502-b557-43f81567e61c.png">

再使用 ps -ef | grep "java"  | grep  {构建ID}
可以看到之前构建进程一直存在。

使用 jstack -F  {进程ID}  可以看到如下信息：
<img width="1341" alt="image" src="https://user-images.githubusercontent.com/16686129/164730858-b8f39766-1552-4a94-aec5-4e8ac1cd2cbe.png">



说明LoggerService.start 被触发产生的进程一直在工作中， 而未被调用 LoggerService.stop.

故障点1：（提前启动LoggerService）
https://github.com/Tencent/bk-ci/blob/1c622875e96d3ff24da7e9f001fab9e573e7a10a/src/backend/worker/worker-agent/src/main/kotlin/com/tencent/devops/agent/runner/WorkRunner.kt#L62

故障点2：（LoggerService.stop闭环位置不对）
https://github.com/Tencent/bk-ci/blob/214a90da2e82eb6f74940b56b7a1de310ab37b54/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/Runner.kt#L91
