### PR TITLE
feat:auth内@ConditionalOnMissingBean优化 #6778

### DIFF
--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/AuthConfiguration.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/AuthConfiguration.kt
@@ -37,9 +37,12 @@ import com.tencent.bk.sdk.iam.service.impl.ApigwHttpClientServiceImpl
 import com.tencent.bk.sdk.iam.service.impl.ManagerServiceImpl
 import com.tencent.devops.auth.service.AuthDeptServiceImpl
 import com.tencent.devops.auth.service.AuthGroupService
+import com.tencent.devops.auth.service.BkLocalManagerServiceImp
 import com.tencent.devops.auth.service.BkPermissionProjectService
 import com.tencent.devops.auth.service.BkPermissionService
 import com.tencent.devops.auth.service.DeptService
+import com.tencent.devops.auth.service.LocalManagerService
+import com.tencent.devops.auth.service.SimpleLocalManagerServiceImpl
 import com.tencent.devops.auth.service.iam.IamCacheService
 import com.tencent.devops.auth.service.iam.PermissionRoleMemberService
 import com.tencent.devops.auth.service.iam.PermissionRoleService
@@ -59,6 +62,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.core.Ordered
 
 @Suppress("ALL")
@@ -165,4 +169,13 @@ class AuthConfiguration {
     fun gitlabStreamProjectPermissionService(
         streamPermissionService: StreamPermissionServiceImpl
     ) = StreamPermissionProjectServiceImpl(streamPermissionService)
+
+    @Bean
+    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "bk_login_v3")
+    @Primary
+    fun bkManagerService() = BkLocalManagerServiceImp()
+
+    @Bean
+    @ConditionalOnMissingBean(LocalManagerService::class)
+    fun simpleManagerService() = SimpleLocalManagerServiceImpl()
 }

--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/AuthConfiguration.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/AuthConfiguration.kt
@@ -41,10 +41,8 @@ import com.tencent.devops.auth.service.BkPermissionProjectService
 import com.tencent.devops.auth.service.BkPermissionService
 import com.tencent.devops.auth.service.DeptService
 import com.tencent.devops.auth.service.iam.IamCacheService
-import com.tencent.devops.auth.service.iam.PermissionProjectService
 import com.tencent.devops.auth.service.iam.PermissionRoleMemberService
 import com.tencent.devops.auth.service.iam.PermissionRoleService
-import com.tencent.devops.auth.service.iam.PermissionService
 import com.tencent.devops.auth.service.stream.GithubStreamPermissionServiceImpl
 import com.tencent.devops.auth.service.stream.GitlabStreamPermissionServiceImpl
 import com.tencent.devops.auth.service.stream.StreamPermissionProjectServiceImpl
@@ -87,11 +85,11 @@ class AuthConfiguration {
     fun iamEsbService() = IamEsbService()
 
     @Bean
-    @ConditionalOnMissingBean(PermissionService::class)
+    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "simple")
     fun permissionService() = SimpleAuthPermissionService()
 
     @Bean
-    @ConditionalOnMissingBean(PermissionProjectService::class)
+    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "simple")
     fun permissionProjectService() = SimpleAuthPermissionProjectService()
 
     @Bean

--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/AuthConfiguration.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/AuthConfiguration.kt
@@ -27,8 +27,8 @@
 
 package com.tencent.devops.auth
 
-import com.tencent.devops.auth.service.SimpleAuthPermissionProjectService
-import com.tencent.devops.auth.service.SimpleAuthPermissionService
+import com.tencent.devops.auth.service.SampleAuthPermissionProjectService
+import com.tencent.devops.auth.service.SampleAuthPermissionService
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.tencent.bk.sdk.iam.config.IamConfiguration
 import com.tencent.bk.sdk.iam.helper.AuthHelper
@@ -89,12 +89,12 @@ class AuthConfiguration {
     fun iamEsbService() = IamEsbService()
 
     @Bean
-    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "simple")
-    fun permissionService() = SimpleAuthPermissionService()
+    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
+    fun permissionService() = SampleAuthPermissionService()
 
     @Bean
-    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "simple")
-    fun permissionProjectService() = SimpleAuthPermissionProjectService()
+    @ConditionalOnProperty(prefix = "auth", name = ["idProvider"], havingValue = "sample")
+    fun permissionProjectService() = SampleAuthPermissionProjectService()
 
     @Bean
     @ConditionalOnMissingBean

--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/BkLocalManagerServiceImp.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/BkLocalManagerServiceImp.kt
@@ -35,7 +35,7 @@ class BkLocalManagerServiceImp @Autowired constructor() : LocalManagerService {
         userId: String,
         projectCode: String,
         action: String,
-        resourceType: String,
+        resourceType: String
     ): Boolean {
         if (isAdmin(userId)) {
             return true

--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/BkLocalManagerServiceImp.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/BkLocalManagerServiceImp.kt
@@ -1,0 +1,53 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.devops.auth.service
+
+import org.springframework.beans.factory.annotation.Autowired
+
+class BkLocalManagerServiceImp @Autowired constructor() : LocalManagerService {
+
+    override fun projectManagerCheck(
+        userId: String,
+        projectCode: String,
+        action: String,
+        resourceType: String,
+    ): Boolean {
+        if (isAdmin(userId)) {
+            return true
+        }
+        return false
+    }
+
+    // 有用户相关功能后， 需要校验真是的管理员账号
+    private fun isAdmin(userId: String): Boolean {
+        if (userId == "admin") {
+            return true
+        }
+        return false
+    }
+}

--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/SampleAuthPermissionProjectService.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/SampleAuthPermissionProjectService.kt
@@ -5,7 +5,7 @@ import com.tencent.devops.common.auth.api.pojo.BKAuthProjectRolesResources
 import com.tencent.devops.common.auth.api.pojo.BkAuthGroup
 import com.tencent.devops.common.auth.api.pojo.BkAuthGroupAndUserList
 
-class SimpleAuthPermissionProjectService : PermissionProjectService {
+class SampleAuthPermissionProjectService : PermissionProjectService {
     override fun getProjectUsers(projectCode: String, group: BkAuthGroup?): List<String> {
         return emptyList()
     }

--- a/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/SampleAuthPermissionService.kt
+++ b/src/backend/ci/core/auth/biz-auth-blueking/src/main/kotlin/com/tencent/devops/auth/service/SampleAuthPermissionService.kt
@@ -4,7 +4,7 @@ import com.tencent.devops.auth.service.iam.PermissionService
 import com.tencent.devops.common.auth.api.AuthPermission
 import org.slf4j.LoggerFactory
 
-class SimpleAuthPermissionService : PermissionService {
+class SampleAuthPermissionService : PermissionService {
     override fun validateUserActionPermission(userId: String, action: String): Boolean {
         return true
     }
@@ -49,6 +49,6 @@ class SimpleAuthPermissionService : PermissionService {
     }
 
     companion object {
-        val logger = LoggerFactory.getLogger(SimpleAuthPermissionService::class.java)
+        val logger = LoggerFactory.getLogger(SampleAuthPermissionService::class.java)
     }
 }

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/common/AuthCoreConfiguration.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/common/AuthCoreConfiguration.kt
@@ -35,8 +35,6 @@ import com.tencent.devops.auth.service.DefaultDeptServiceImpl
 import com.tencent.devops.auth.service.DeptService
 import com.tencent.devops.auth.service.EmptyPermissionExtServiceImpl
 import com.tencent.devops.auth.service.EmptyPermissionUrlServiceImpl
-import com.tencent.devops.auth.service.LocalManagerService
-import com.tencent.devops.auth.service.SimpleLocalManagerServiceImpl
 import com.tencent.devops.auth.utils.HostUtils
 import com.tencent.devops.common.client.ClientTokenService
 import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
@@ -145,8 +143,4 @@ class AuthCoreConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = ["permissionUrlService"])
     fun permissionUrlService() = EmptyPermissionUrlServiceImpl()
-
-    @Bean
-    @ConditionalOnMissingBean(LocalManagerService::class)
-    fun simpleManagerService() = SimpleLocalManagerServiceImpl()
 }


### PR DESCRIPTION
去除PermissionService,PermissionProjectService通过ConditionalOnMissingBean的兜底。 必须idProvider=simple才实例化。 
可能导致非法的idProvider无法启动。但是排除了非法idProvider通过Simple来鉴权的风险