### PR TITLE
ci支持用户变更访问的web端口

### DIFF
--- a/scripts/bk-ci-modify-http-port.sh
+++ b/scripts/bk-ci-modify-http-port.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# 支持蓝盾调整访问端口
+set -eu
+trap "on_ERR;" ERR
+on_ERR (){
+  local fn=$0 ret=$? lineno=${BASH_LINENO:-$LINENO}
+  echo >&2 "ERROR $fn exit with $ret at line $lineno: $(sed -n ${lineno}p $0)."
+}
+
+set -a
+CTRL_DIR="${CTRL_DIR:-/data/install}"
+BK_PKG_SRC_PATH=${BK_PKG_SRC_PATH:-/data/src}
+BK_CI_SRC_DIR=${BK_CI_SRC_DIR:-$BK_PKG_SRC_PATH/ci}
+ci_env_default="$CTRL_DIR/bin/default/ci.env"
+ci_env_03="$CTRL_DIR/bin/03-userdef/ci.env"
+ci_env_04="$CTRL_DIR/bin/04-final/ci.env"
+
+for i in ${ci_env_03} ${ci_env_04} ; do sed -i "/BK_CI_HTTP_PORT/d;/BK_CI_FQDN/d;/BK_CI_PUBLIC_URL/d;/BK_CI_REPOSITORY_GITLAB_URL/d" ${i} ; done
+
+source $CTRL_DIR/load_env.sh
+source $CTRL_DIR/bin/02-dynamic/hosts.env
+set +a
+BK_CI_HTTP_PORT=$(awk '{print $1}' /tmp/bk_ci_http_port)
+
+set_env03_en (){
+  for kv in "$@"; do
+    echo "SET_ENV03_EN: $ci_env_03 中已赋值，重新覆盖生效 $kv"
+    [[ "$kv" =~ ^[A-Z0-9_]+=$ ]] && echo -e "\033[31;1m注意：\033[m$kv 赋值为空，请检查蓝鲸是否安装正确
+，或人工修改env文件后重试。"
+    # 如果已经有相同的行，则也不覆盖，防止赋值为空时不断追加。
+    p_d=$(echo ${kv}|awk -v FS="=" '{print $1}')
+    sed -i "/${p_d}/d" "$ci_env_03"
+    grep -qxF "$kv" "$ci_env_03" 2>/dev/null || echo "$kv" >> "$ci_env_03"
+    eval "$kv"  # 立即生效
+  done
+}
+
+cd "$CTRL_DIR"
+pkg_env_tpl="$BK_PKG_SRC_PATH/ci/scripts/bkenv.properties"
+if [ -f "$pkg_env_tpl" ] && ! diff -q "$pkg_env_tpl" "$ci_env_default" 2>/dev/null; then
+  echo "安装包中存在新版env文件, 更新ci.env模板: $ci_env_default"
+  cp -v "$pkg_env_tpl" "$ci_env_default" || echo "更新ci.env模板失败."
+fi
+
+set_env03_en BK_CI_HTTP_PORT=${BK_CI_HTTP_PORT} \
+  BK_CI_FQDN=$(echo ${BK_PAAS_PUBLIC_ADDR}|sed "s#paas#devops#g;s#:80#:${BK_CI_HTTP_PORT}#g") \
+  BK_CI_PUBLIC_URL=http://\$BK_CI_FQDN \
+  BK_CI_REPOSITORY_GITLAB_URL=http://\$BK_CI_FQDN
+
+echo ${BK_CI_FQDN} ${BK_CI_PUBLIC_URL} ${BK_CI_REPOSITORY_GITLAB_URL}
+
+echo "合并env."
+./bin/merge_env.sh ci &>/dev/null || true
+

--- a/scripts/bk-ci-modify-paas-web-entrance.sh
+++ b/scripts/bk-ci-modify-paas-web-entrance.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# 调整蓝盾端口修改后的，paas页面访问链接修改
+set -eu
+trap "on_ERR;" ERR
+on_ERR (){
+  local fn=$0 ret=$? lineno=${BASH_LINENO:-$LINENO}
+  echo >&2 "ERROR $fn exit with $ret at line $lineno: $(sed -n ${lineno}p $0)."
+}
+
+set -a
+CTRL_DIR="${CTRL_DIR:-/data/install}"
+BK_PKG_SRC_PATH=${BK_PKG_SRC_PATH:-/data/src}
+BK_CI_SRC_DIR=${BK_CI_SRC_DIR:-$BK_PKG_SRC_PATH/ci}
+source $CTRL_DIR/load_env.sh
+set +a
+
+source $CTRL_DIR/load_env.sh
+
+# 修改蓝鲸，应用列表导航
+if [[ $(mysql --login-path=mysql-paas -NBe "select external_url from open_paas.paas_app where code='bk_ci'") == "$BK_CI_PUBLIC_URL" ]] ; then
+    echo "open_paas ci web entrance same as BK_CI_PUBLIC_URL , no need modify 1st" && exit 0
+else
+    mysql --login-path=mysql-paas -Be "update open_paas.paas_app set external_url='$BK_CI_PUBLIC_URL' where code='bk_ci'"
+    if [[ $(mysql --login-path=mysql-paas -NBe "select external_url from open_paas.paas_app where code='bk_ci'") == "$BK_CI_PUBLIC_URL" ]] ; then
+        echo "open_paas ci web entrance modify success 2nd" && exit 0
+    else
+        echo "open_paas ci web entrance modify failed 2nd" && exit 2
+    fi
+fi
+

--- a/scripts/bk-ci-special-upgrade.sh
+++ b/scripts/bk-ci-special-upgrade.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -a
+CTRL_DIR="/data/install"
+source ${CTRL_DIR:-/data/install}/load_env.sh
+set +a
+BK_PKG_SRC_PATH=${BK_PKG_SRC_PATH:-/data/src}
+BK_CI_SRC_DIR=${BK_CI_SRC_DIR:-$BK_PKG_SRC_PATH/ci}
+
+# 强制安装蓝鲸社区版提供的kona jdk, 规避用户自定义java导致的异常.
+echo "check and install Tencent KonaJDK."
+if /usr/bin/java -version | grep -F "Tencent Kona 8."; then
+  echo "Tencent KonaJDK was installed."
+else
+  $CTRL_DIR/bin/install_java.sh -p "$BK_HOME" -f $BK_PKG_SRC_PATH/java8.tgz
+fi
+yum install -y fontconfig  # v1.5.7前project需要读写字体.
+
+echo "projs is agentless artifactory auth dispatch dispatch-docker dockerhost environment gateway image log misc notify openapi plugin process project quality repository store ticket turbo websocket."
+${BK_CI_SRC_DIR}/scripts/bk-ci-upgrade.sh agentless artifactory auth dispatch dispatch-docker dockerhost environment gateway image log misc notify openapi plugin process project quality repository store ticket turbo websocket
+

--- a/scripts/bkce-set-env03.sh
+++ b/scripts/bkce-set-env03.sh
@@ -62,14 +62,12 @@ if [ -f "$pkg_env_tpl" ] && ! diff -q "$pkg_env_tpl" "$ci_env_default" 2>/dev/nu
   cp -v "$pkg_env_tpl" "$ci_env_default" || echo "更新ci.env模板失败."
 fi
 
-echo "检查设置 CI 基础配置"
+echo "检查设置 CI 基础配置，一次生成"
 set_env03 BK_HTTP_SCHEMA=http \
   BK_DOMAIN=$BK_DOMAIN \
   BK_PAAS_PUBLIC_URL=$BK_PAAS_PUBLIC_URL \
   BK_CI_AUTH_PROVIDER=bk_login_v3 \
-  BK_CI_FQDN=$(echo ${BK_PAAS_PUBLIC_ADDR}|sed "s#paas#devops#g;s#:80##g") \
   BK_HOME=$BK_HOME \
-  BK_CI_PUBLIC_URL=http://\$BK_CI_FQDN \
   BK_SSM_HOST=bkssm.service.consul \
   BK_IAM_PRIVATE_URL=$BK_IAM_PRIVATE_URL \
   BK_PAAS_FQDN=${BK_PAAS_FQDN:-${BK_PAAS_PUBLIC_ADDR%:*}} \
@@ -79,7 +77,6 @@ set_env03 BK_HTTP_SCHEMA=http \
   BK_LICENSE_PRIVATE_URL=$BK_LICENSE_PRIVATE_URL \
   BK_CI_PAAS_DIALOG_LOGIN_URL=$BK_PAAS_PUBLIC_URL/login/plain/?c_url= \
   BK_CI_PAAS_LOGIN_URL=\$BK_PAAS_PUBLIC_URL/login/\?c_url= \
-  BK_CI_REPOSITORY_GITLAB_URL=http://\$BK_CI_FQDN \
   BK_CI_APP_CODE=bk_ci \
   BK_CI_APP_TOKEN=$(uuid_v4) \
   BK_CI_INFLUXDB_ADDR=$BK_CI_IP0:8086 \
@@ -97,8 +94,11 @@ set_env03 BK_CI_MYSQL_ADDR=${BK_MYSQL_IP}:3306 BK_CI_MYSQL_USER=bk_ci BK_CI_MYSQ
 # 复用redis, 读取密码, 刷新03env.
 set_env03 BK_CI_REDIS_HOST=$BK_REDIS_IP BK_CI_REDIS_PASSWORD=$BK_PAAS_REDIS_PASSWORD
 
+# 调整BK_CI_AUTH_PROVIDER及URL等
 set_env03_en BK_CI_AUTH_PROVIDER=bk_login_v3 \
-  BK_CI_FQDN=$(echo ${BK_PAAS_PUBLIC_ADDR}|sed "s#paas#devops#g;s#:80##g")
+  BK_CI_FQDN=$(echo ${BK_PAAS_PUBLIC_ADDR}|sed "s#paas#devops#g;s#:80##g") \
+  BK_CI_PUBLIC_URL=http://\$BK_CI_FQDN \
+  BK_CI_REPOSITORY_GITLAB_URL=http://\$BK_CI_FQDN
 
 if grep -w repo $CTRL_DIR/install.config|grep -v ^\# ; then
   set_env03_en BK_REPO_GATEWAY_IP=$BK_REPO_GATEWAY_IP \


### PR DESCRIPTION
新增变更依赖脚本：
1. bk-ci-modify-http-port.sh
2. bk-ci-modify-paas-web-entrance.sh
3. bk-ci-special-upgrade.sh