### PR TITLE
支持配置agent构建日志文件的过期清理时间 #6944

### DIFF
--- a/src/agent/src/pkg/upgrade/download/download_unix.go
+++ b/src/agent/src/pkg/upgrade/download/download_unix.go
@@ -23,7 +23,7 @@ func getServerFileArch() string {
 
 func DownloadUpgradeFile(saveDir string) (string, error) {
 	return api.DownloadUpgradeFile(
-		"upgrade/upgrader"+getServerFileArch(), saveDir+"/"+config.UpgraderFileServerMacOs,
+		"upgrade/upgrader"+getServerFileArch(), saveDir+"/"+config.UpgraderFileClientLinux,
 	)
 }
 


### PR DESCRIPTION
修正错误的命名，在新安装的agent中，会导致无法正常升级