### PR TITLE
feat: 文本框变量在构建任务历史执行页面中，配置预览时调整为textarea，避免input对文本框变量值展示遗漏 issue #6938

### DIFF
--- a/src/frontend/devops-pipeline/src/components/atomFormField/VuexTextarea/index.vue
+++ b/src/frontend/devops-pipeline/src/components/atomFormField/VuexTextarea/index.vue
@@ -20,7 +20,7 @@
         render (h) {
             const { value, readOnly, handleInput, name, handleBlur, title, clickUnfold, placeholder } = this
             return (
-                <textarea placeholder={placeholder} title={title} onBlur={handleBlur} onInput={handleInput} class={['bk-form-textarea pointer-events-auto', clickUnfold ? 'textarea-styles' : '']} name={name} disabled={readOnly} value={value} />
+                <textarea placeholder={placeholder} title={title} onBlur={handleBlur} onInput={handleInput} class={['bk-form-textarea pointer-events-auto', clickUnfold ? 'textarea-styles' : '', readOnly ? 'hover-textarea-styles' : '']} name={name} disabled={readOnly} value={value} />
             )
         }
     }
@@ -37,6 +37,12 @@
         line-height: 20px !important;
         margin-top: 1px;
         &:focus {
+            height: 100px!important;
+            z-index: 10;
+        }
+    }
+    .hover-textarea-styles {
+        &:hover {
             height: 100px!important;
             z-index: 10;
         }


### PR DESCRIPTION
feat: 文本框变量在构建任务历史执行页面中，配置预览时调整为textarea，避免input对文本框变量值展示遗漏 issue #6938