### PR TITLE
bugfix: 流水线参数为代码库，选择gitlab无法保存 issue #7067

### DIFF
--- a/src/frontend/devops-pipeline/src/store/modules/atom/paramsConfig.js
+++ b/src/frontend/devops-pipeline/src/store/modules/atom/paramsConfig.js
@@ -275,7 +275,7 @@ export const CODE_LIB_TYPE = [
         name: 'GITHUB'
     },
     {
-        id: 'GITLAB',
+        id: 'CODE_GITLAB',
         name: 'GITLAB'
     }
 ]


### PR DESCRIPTION
bugfix: 流水线参数为代码库，选择gitlab无法保存 issue #7067