### PR TITLE
【Stream】技术需求：request&trigger 监听mq的traceId设置优化 #7301

### DIFF
--- a/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamRequest/StreamRequestListener.kt
+++ b/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamRequest/StreamRequestListener.kt
@@ -61,14 +61,6 @@ class StreamRequestListener @Autowired constructor(
         ]
     )
     fun listenStreamRequestEvent(streamRequestEvent: StreamRequestEvent) {
-        val traceId = MDC.get(TraceTag.BIZID)
-        if (traceId.isNullOrEmpty()) {
-            if (!streamRequestEvent.traceId.isNullOrEmpty()) {
-                MDC.put(TraceTag.BIZID, streamRequestEvent.traceId)
-            } else {
-                MDC.put(TraceTag.BIZID, TraceTag.buildBiz())
-            }
-        }
         try {
             steamRequestService.externalCodeGitBuild(
                 eventType = streamRequestEvent.eventType,
@@ -76,8 +68,6 @@ class StreamRequestListener @Autowired constructor(
             )
         } catch (ignore: Throwable) {
             logger.warn("Fail to request stream $streamRequestEvent", ignore)
-        } finally {
-            MDC.remove(TraceTag.BIZID)
         }
     }
 

--- a/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamRequest/StreamRequestListener.kt
+++ b/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamRequest/StreamRequestListener.kt
@@ -27,11 +27,9 @@
 
 package com.tencent.devops.stream.trigger.mq.streamRequest
 
-import com.tencent.devops.common.service.trace.TraceTag
 import com.tencent.devops.stream.constant.MQ
 import com.tencent.devops.stream.trigger.StreamTriggerRequestService
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.amqp.core.ExchangeTypes
 import org.springframework.amqp.rabbit.annotation.Exchange
 import org.springframework.amqp.rabbit.annotation.Queue

--- a/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerListener.kt
+++ b/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerListener.kt
@@ -49,19 +49,9 @@ class StreamTriggerListener @Autowired constructor(
 
     fun listenStreamTriggerEvent(event: StreamTriggerEvent) {
         try {
-            val traceId = MDC.get(TraceTag.BIZID)
-            if (traceId.isNullOrEmpty()) {
-                if (!event.traceId.isNullOrEmpty()) {
-                    MDC.put(TraceTag.BIZID, event.traceId)
-                } else {
-                    MDC.put(TraceTag.BIZID, TraceTag.buildBiz())
-                }
-            }
             run(event)
         } catch (e: Throwable) {
             logger.error("listenStreamTriggerEvent|error", e)
-        } finally {
-            MDC.remove(TraceTag.BIZID)
         }
     }
 

--- a/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerListener.kt
+++ b/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerListener.kt
@@ -27,12 +27,10 @@
 
 package com.tencent.devops.stream.trigger.mq.streamTrigger
 
-import com.tencent.devops.common.service.trace.TraceTag
 import com.tencent.devops.stream.trigger.StreamYamlTrigger
 import com.tencent.devops.stream.trigger.actions.EventActionFactory
 import com.tencent.devops.stream.trigger.exception.handler.StreamTriggerExceptionHandler
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 

--- a/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerMQConfig.kt
+++ b/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerMQConfig.kt
@@ -27,6 +27,7 @@
 package com.tencent.devops.stream.trigger.mq.streamTrigger
 
 import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQEventDispatcher
+import com.tencent.devops.common.event.dispatcher.pipeline.mq.Tools
 import com.tencent.devops.stream.constant.MQ
 import org.springframework.amqp.core.Binding
 import org.springframework.amqp.core.BindingBuilder
@@ -82,19 +83,21 @@ class StreamTriggerMQConfig {
         @Autowired streamTriggerListener: StreamTriggerListener,
         @Autowired messageConverter: Jackson2JsonMessageConverter
     ): SimpleMessageListenerContainer {
-        val container = SimpleMessageListenerContainer(connectionFactory)
-        container.setQueueNames(requestTriggerQueue.name)
-        container.setConcurrentConsumers(30)
-        container.setMaxConcurrentConsumers(30)
-        container.setAmqpAdmin(rabbitAdmin)
-        container.setPrefetchCount(1)
-
         val adapter = MessageListenerAdapter(
             streamTriggerListener,
             streamTriggerListener::listenStreamTriggerEvent.name
         )
         adapter.setMessageConverter(messageConverter)
-        container.setMessageListener(adapter)
-        return container
+        return Tools.createSimpleMessageListenerContainerByAdapter(
+            connectionFactory = connectionFactory,
+            queue = requestTriggerQueue,
+            rabbitAdmin = rabbitAdmin,
+            adapter = adapter,
+            startConsumerMinInterval = 10000,
+            consecutiveActiveTrigger = 5,
+            concurrency = 30,
+            maxConcurrency = 30,
+            prefetchCount = 1
+        )
     }
 }

--- a/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerMQConfig.kt
+++ b/src/backend/ci/core/stream/biz-stream/src/main/kotlin/com/tencent/devops/stream/trigger/mq/streamTrigger/StreamTriggerMQConfig.kt
@@ -83,16 +83,14 @@ class StreamTriggerMQConfig {
         @Autowired streamTriggerListener: StreamTriggerListener,
         @Autowired messageConverter: Jackson2JsonMessageConverter
     ): SimpleMessageListenerContainer {
-        val adapter = MessageListenerAdapter(
-            streamTriggerListener,
-            streamTriggerListener::listenStreamTriggerEvent.name
-        )
-        adapter.setMessageConverter(messageConverter)
         return Tools.createSimpleMessageListenerContainerByAdapter(
             connectionFactory = connectionFactory,
             queue = requestTriggerQueue,
             rabbitAdmin = rabbitAdmin,
-            adapter = adapter,
+            adapter = MessageListenerAdapter(
+                streamTriggerListener,
+                streamTriggerListener::listenStreamTriggerEvent.name
+            ).also { it.setMessageConverter(messageConverter) },
             startConsumerMinInterval = 10000,
             consecutiveActiveTrigger = 5,
             concurrency = 30,


### PR DESCRIPTION
1、StreamRequestListener去掉显示的traceId传递。
2、StreamTriggerListener去掉显示的traceId传递。
3、StreamTriggerMQConfig中streamRequestTriggerContainer改成调用Tools.kt的方法：createSimpleMessageListenerContainerByAdapter，自动传递traceId。