### PR TITLE
docs: Update issue templates #7445

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,23 +1,90 @@
 ---
 name: Bug Report
 about: Report a bug encountered while operating bk-ci
+title: ''
 labels: kind/bug
+assignees: ''
+
 ---
 
-<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!-->
+- type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+        If this matter is security related, please disclose it privately via https://github.com/Tencent/bk-ci/blob/master/SECURITY.md
+    validations:
+      required: true
 
-**What happened**:
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
 
-**What you expected to happen**:
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true
 
-**How to reproduce it (as minimally and precisely as possible)**:
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
 
-**Anything else we need to know?**:
+  - type: textarea
+    id: bkciVersion
+    attributes:
+      label: bk-ci version
+      value: |
+        <details>
 
-**Environment**:
-- bk-ci version (use `cat VERSION` in installed dir):
-- Cloud provider or hardware configuration:
-- OS (e.g: `cat /etc/os-release`):
-- Kernel (e.g. `uname -a`):
-- Install tools:
-- Others:
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: cloudProvider
+    attributes:
+      label: Cloud provider
+      value: |
+        <details>
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    id: osVersion
+    attributes:
+      label: OS version
+      value: |
+        <details>
+
+        ```console
+        # On Linux:
+        $ cat /etc/os-release
+        # paste output here
+        $ uname -a
+        # paste output here
+
+        # On Windows:
+        C:\> wmic os get Caption, Version, BuildNumber, OSArchitecture
+        # paste output here
+        ```
+
+        </details>
+
+  - type: textarea
+    id: installer
+    attributes:
+      label: Install tools
+      value: |
+        <details>
+
+        </details>

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,13 +1,8 @@
----
 name: Bug Report
-about: Report a bug encountered while operating bk-ci
-title: ''
+description: Report a bug encountered while operating bk-ci
 labels: kind/bug
-assignees: ''
-
----
-
-- type: textarea
+body:
+  - type: textarea
     id: problem
     attributes:
       label: What happened?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,13 +1,8 @@
----
 name: Enhancement Request
-about: Suggest an enhancement to the bk-ci project
-title: ''
+description: Suggest an enhancement to the bk-ci project
 labels: kind/enhancement
-assignees: ''
-
----
-
-- type: textarea
+body:
+  - type: textarea
     id: feature
     attributes:
       label: What would you like to be added?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,11 +1,24 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement to the bk-ci project
+title: ''
 labels: kind/enhancement
+assignees: ''
 
 ---
-<!-- Please only use this template for submitting enhancement requests -->
 
-**What would you like to be added**:
+- type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: |
+        Feature requests are unlikely to make progress as issues. Please consider engaging with SIGs on slack and mailing lists, instead.
+    validations:
+      required: true
 
-**Why is this needed**:
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,17 +1,13 @@
 ---
 name: Support Request
 about: Support request or question relating to bk-ci
+title: ''
 labels: help wanted
+assignees: ''
 
 ---
 
-<!--
-STOP -- PLEASE READ!
-
-GitHub is not the right place for support requests.
-
-If you're looking for help, check [BlueKing Q&A Community](https://bk.tencent.com/s-mart/community/question?selectTag=%25E8%2593%259D%25E7%259B%25BE&bestType=latest).
-
-You can also post your question on the QQ Group: 495299374.
-
--->
+contact_links:
+  - name: Support Request
+    url: https://support.qq.com/product/425695
+    about: Support request or question relating to BK-CI

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,12 +1,3 @@
----
-name: Support Request
-about: Support request or question relating to bk-ci
-title: ''
-labels: help wanted
-assignees: ''
-
----
-
 contact_links:
   - name: Support Request
     url: https://support.qq.com/product/425695


### PR DESCRIPTION
引入GitHub Issue Form Template功能，详见：https://docs.github.com/cn/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms