### PR TITLE
feat : windows下ue的pump模式支持

### DIFF
--- a/src/backend/booster/bk_dist/booster/command/command.go
+++ b/src/backend/booster/bk_dist/booster/command/command.go
@@ -70,6 +70,10 @@ const (
 	FlagPumpDisableMacro     = "pump_disable_macro"
 	FlagPumpIncludeSysHeader = "pump_include_sys_header"
 	FlagPumpCheck            = "pump_check"
+	FlagPumpCache            = "pump_cache"
+	FlagPumpCacheDir         = "pump_cache_dir"
+	FlagPumpCacheSizeMaxMB   = "pump_cache_size_max_MB"
+	FlagPumpCacheRemoveAll   = "pump_cache_remove_all"
 	FlagForceLocalList       = "force_local_list"
 	FlagNoWork               = "no_work"
 	FlagControllerNoWait     = "controller_no_wait"
@@ -84,6 +88,7 @@ const (
 	FlagDisableFileLock      = "disable_file_lock"
 	FlagAutoResourceMgr      = "auto_resource_mgr"
 	FlagResIdleSecsForFree   = "res_idle_secs_for_free"
+	FlagSendCork             = "send_cork"
 
 	EnvBuildIDOld  = "TURBO_PLAN_BUILD_ID"
 	EnvBuildID     = "TBS_BUILD_ID"
@@ -285,6 +290,22 @@ var (
 			Name:  "pump_check",
 			Usage: "check pre-process in pump mode",
 		},
+		commandCli.BoolFlag{
+			Name:  "pump_cache",
+			Usage: "use cached depend files in pump mode",
+		},
+		commandCli.StringFlag{
+			Name:  "pump_cache_dir",
+			Usage: "specify the pump cache dir",
+		},
+		commandCli.IntFlag{
+			Name:  "pump_cache_size_max_MB",
+			Usage: "max pump cache size(MB)",
+		},
+		commandCli.BoolFlag{
+			Name:  "pump_cache_remove_all",
+			Usage: "remove all of pump cache files",
+		},
 		commandCli.StringSliceFlag{
 			Name:  "force_local_list, fll",
 			Usage: "key list which will be force executed locally",
@@ -340,6 +361,10 @@ var (
 		commandCli.IntFlag{
 			Name:  "res_idle_secs_for_free",
 			Usage: "free this resource if oever this idle seconds, only used when auto_resource_mgr is true",
+		},
+		commandCli.BoolFlag{
+			Name:  "send_cork",
+			Usage: "send files like tcp cork",
 		},
 	}
 )

--- a/src/backend/booster/bk_dist/booster/command/process.go
+++ b/src/backend/booster/bk_dist/booster/command/process.go
@@ -215,6 +215,11 @@ func newBooster(c *commandCli.Context) (*pkg.Booster, error) {
 		resIdleSecsForFree = c.Int(FlagResIdleSecsForFree)
 	}
 
+	pumpCacheSizeMaxMB := int32(c.Int(FlagPumpCacheSizeMaxMB))
+	if pumpCacheSizeMaxMB <= 0 {
+		pumpCacheSizeMaxMB = 1024
+	}
+
 	// generate a new booster.
 	cmdConfig := dcType.BoosterConfig{
 		Type:      dcType.GetBoosterType(bt),
@@ -264,6 +269,10 @@ func newBooster(c *commandCli.Context) (*pkg.Booster, error) {
 			PumpDisableMacro:     c.Bool(FlagPumpDisableMacro),
 			PumpIncludeSysHeader: c.Bool(FlagPumpIncludeSysHeader),
 			PumpCheck:            c.Bool(FlagPumpCheck),
+			PumpCache:            c.Bool(FlagPumpCache),
+			PumpCacheDir:         c.String(FlagPumpCacheDir),
+			PumpCacheSizeMaxMB:   pumpCacheSizeMaxMB,
+			PumpCacheRemoveAll:   c.Bool(FlagPumpCacheRemoveAll),
 			ForceLocalList:       c.StringSlice(FlagForceLocalList),
 			NoWork:               c.Bool(FlagNoWork),
 			WriteMemroy:          c.Bool(FlagWriteMemroMemroy),
@@ -306,6 +315,7 @@ func newBooster(c *commandCli.Context) (*pkg.Booster, error) {
 			DisableFileLock:    c.Bool(FlagDisableFileLock),
 			AutoResourceMgr:    c.Bool(FlagAutoResourceMgr),
 			ResIdleSecsForFree: resIdleSecsForFree,
+			SendCork:           c.Bool(FlagSendCork),
 		},
 	}
 

--- a/src/backend/booster/bk_dist/booster/pkg/booster.go
+++ b/src/backend/booster/bk_dist/booster/pkg/booster.go
@@ -48,6 +48,8 @@ const (
 	renderKeyJobs = "JOBS"
 
 	osWindows = "windows"
+
+	envValueTrue = "true"
 )
 
 // ExtraItems describe the info from extra-project-data
@@ -233,7 +235,7 @@ func (b *Booster) getWorkersEnv() map[string]string {
 	requiredEnv[env.BoosterType] = b.config.Type.String()
 	requiredEnv[env.ProjectID] = b.config.ProjectID
 	if b.config.BatchMode {
-		requiredEnv[env.BatchMode] = "true"
+		requiredEnv[env.BatchMode] = envValueTrue
 	} else {
 		requiredEnv[env.BatchMode] = "false"
 	}
@@ -257,7 +259,7 @@ func (b *Booster) getWorkersEnv() map[string]string {
 	}
 
 	if b.config.Works.CheckMd5 {
-		requiredEnv[env.KeyCommonCheckMd5] = "true"
+		requiredEnv[env.KeyCommonCheckMd5] = envValueTrue
 	}
 
 	if b.work != nil {
@@ -273,27 +275,27 @@ func (b *Booster) getWorkersEnv() map[string]string {
 	}
 
 	if b.config.Works.SupportDirectives {
-		requiredEnv[env.KeyExecutorSupportDirectives] = "true"
+		requiredEnv[env.KeyExecutorSupportDirectives] = envValueTrue
 	}
 
 	if b.config.Works.Pump {
-		requiredEnv[env.KeyExecutorPump] = "true"
+		requiredEnv[env.KeyExecutorPump] = envValueTrue
 	}
 
 	if b.config.Works.PumpDisableMacro {
-		requiredEnv[env.KeyExecutorPumpDisableMacro] = "true"
+		requiredEnv[env.KeyExecutorPumpDisableMacro] = envValueTrue
 	}
 
 	if b.config.Works.PumpIncludeSysHeader {
-		requiredEnv[env.KeyExecutorPumpIncludeSysHeader] = "true"
+		requiredEnv[env.KeyExecutorPumpIncludeSysHeader] = envValueTrue
 	}
 
 	if b.config.Works.PumpCheck {
-		requiredEnv[env.KeyExecutorPumpCheck] = "true"
+		requiredEnv[env.KeyExecutorPumpCheck] = envValueTrue
 	}
 
 	if b.config.Works.PumpCache {
-		requiredEnv[env.KeyExecutorPumpCache] = "true"
+		requiredEnv[env.KeyExecutorPumpCache] = envValueTrue
 	}
 
 	requiredEnv[env.KeyExecutorPumpCacheDir] = b.config.Works.PumpCacheDir
@@ -304,11 +306,11 @@ func (b *Booster) getWorkersEnv() map[string]string {
 	}
 
 	if b.config.Works.WorkerSideCache {
-		requiredEnv[env.KeyExecutorWorkerSideCache] = "true"
+		requiredEnv[env.KeyExecutorWorkerSideCache] = envValueTrue
 	}
 
 	if b.config.Works.LocalRecord {
-		requiredEnv[env.KeyExecutorLocalRecord] = "true"
+		requiredEnv[env.KeyExecutorLocalRecord] = envValueTrue
 	}
 
 	if len(b.config.Works.ForceLocalList) > 0 {
@@ -316,7 +318,7 @@ func (b *Booster) getWorkersEnv() map[string]string {
 	}
 
 	if b.config.Works.WriteMemroy {
-		requiredEnv[env.KeyExecutorWriteMemory] = "true"
+		requiredEnv[env.KeyExecutorWriteMemory] = envValueTrue
 	}
 
 	if b.config.Works.IdleKeepSecs > 0 {

--- a/src/backend/booster/bk_dist/common/env/env.go
+++ b/src/backend/booster/bk_dist/common/env/env.go
@@ -81,6 +81,9 @@ const (
 	KeyCustomSetting = "CUSTOM_SETTINGS"
 
 	CommonBKEnvSepKey = "!!|!!"
+
+	KeyRemoteEnvAppend    = "REMOTE_ENV_APPEND"
+	KeyRemoteEnvOverwrite = "REMOTE_ENV_OVERWRITE"
 )
 
 // GetEnvKey return env value by specified key

--- a/src/backend/booster/bk_dist/common/env/env.go
+++ b/src/backend/booster/bk_dist/common/env/env.go
@@ -77,6 +77,7 @@ const (
 	KeyWorkerCacheDir      = "CACHE_DIR"
 	KeyWorkerCachePoolSize = "CACHE_POOL_SIZE"
 	KeyWorkerCacheMinSize  = "CACHE_MIN_SIZE"
+	KeyWorkerMemPerJob     = "MEM_PER_JOB_4_WORKER" // memory per job
 
 	KeyCustomSetting = "CUSTOM_SETTINGS"
 

--- a/src/backend/booster/bk_dist/common/env/env.go
+++ b/src/backend/booster/bk_dist/common/env/env.go
@@ -43,6 +43,9 @@ const (
 	KeyExecutorPumpDisableMacro        = "PUMP_DISABLE_MACRO"
 	KeyExecutorPumpIncludeSysHeader    = "PUMP_INCLUDE_SYS_HEADER"
 	KeyExecutorPumpCheck               = "PUMP_CHECK"
+	KeyExecutorPumpCache               = "PUMP_CACHE"             // cache pump inlude files
+	KeyExecutorPumpCacheDir            = "PUMP_CACHE_DIR"         // cache pump inlude files
+	KeyExecutorPumpCacheSizeMaxMB      = "PUMP_CACHE_SIZE_MAX_MB" // cache pump inlude files
 	KeyExecutorForceLocalKeys          = "FORCE_LOCAL_KEYS"
 	KeyExecutorEnvProfile              = "ENV_PROFILE"
 	KeyExecutorWorkerSideCache         = "WORKER_SIDE_CACHE"

--- a/src/backend/booster/bk_dist/common/pump/pump.go
+++ b/src/backend/booster/bk_dist/common/pump/pump.go
@@ -13,7 +13,11 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"strconv"
+
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/env"
+	dcEnv "github.com/Tencent/bk-ci/src/booster/bk_dist/common/env"
 )
 
 const (
@@ -139,4 +143,34 @@ func (c *Client) read() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func IsPump(env *env.Sandbox) bool {
+	return env.GetEnv(dcEnv.KeyExecutorPump) != ""
+}
+
+func SupportPump(env *env.Sandbox) bool {
+	return IsPump(env) && runtime.GOOS == "windows"
+}
+
+func IsPumpCache(env *env.Sandbox) bool {
+	return env.GetEnv(dcEnv.KeyExecutorPumpCache) != ""
+}
+
+func PumpCacheDir(env *env.Sandbox) string {
+	return env.GetEnv(dcEnv.KeyExecutorPumpCacheDir)
+}
+
+func PumpCacheSizeMaxMB(env *env.Sandbox) int32 {
+	strsize := env.GetEnv(dcEnv.KeyExecutorPumpCacheSizeMaxMB)
+	if strsize != "" {
+		size, err := strconv.Atoi(strsize)
+		if err != nil {
+			return -1
+		} else {
+			return int32(size)
+		}
+	}
+
+	return -1
 }

--- a/src/backend/booster/bk_dist/common/sdk/controller.go
+++ b/src/backend/booster/bk_dist/common/sdk/controller.go
@@ -127,6 +127,7 @@ type ControllerConfig struct {
 	DisableFileLock    bool
 	AutoResourceMgr    bool
 	ResIdleSecsForFree int
+	SendCork           bool
 }
 
 // Target return the server ip and port of controller

--- a/src/backend/booster/bk_dist/common/sdk/worker.go
+++ b/src/backend/booster/bk_dist/common/sdk/worker.go
@@ -72,6 +72,7 @@ type BKCommand struct {
 	Params          []string   `json:"params"`
 	Inputfiles      []FileDesc `json:"input_files"`
 	ResultFiles     []string   `json:"result_files"`
+	Env             []string   `json:"env"`
 }
 
 // Result result after execute command

--- a/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -300,7 +301,7 @@ func (s *Sandbox) startCommand(name string, arg ...string) (*exec.Cmd, error) {
 	if !strings.HasPrefix(name, ".") {
 		name, err = s.LookPath(name)
 	}
-	
+
 	var cmd *exec.Cmd
 	if s.Ctx != nil {
 		cmd = exec.CommandContext(s.Ctx, name, arg...)

--- a/src/backend/booster/bk_dist/common/types/booster.go
+++ b/src/backend/booster/bk_dist/common/types/booster.go
@@ -105,7 +105,12 @@ type BoosterWorks struct {
 	PumpDisableMacro     bool
 	PumpIncludeSysHeader bool
 	PumpCheck            bool
-	ForceLocalList       []string
+	PumpCache            bool
+	PumpCacheDir         string
+	PumpCacheSizeMaxMB   int32
+	PumpCacheRemoveAll   bool
+
+	ForceLocalList []string
 
 	NoWork bool
 

--- a/src/backend/booster/bk_dist/common/util/util.go
+++ b/src/backend/booster/bk_dist/common/util/util.go
@@ -118,6 +118,13 @@ func GetLogsDir() string {
 	return dir
 }
 
+// GetPumpCacheDir get the runtime pump cache dir
+func GetPumpCacheDir() string {
+	dir := path.Join(GetRuntimeDir(), "pump_cache")
+	_ = os.MkdirAll(dir, os.ModePerm)
+	return dir
+}
+
 // GetRecordDir get the record dir
 func GetRecordDir() string {
 	dir := filepath.Join(GetGlobalDir(), "record")

--- a/src/backend/booster/bk_dist/controller/config/config.go
+++ b/src/backend/booster/bk_dist/controller/config/config.go
@@ -40,6 +40,8 @@ type ServerConfig struct {
 
 	AutoResourceMgr    bool `json:"auto_resource_mgr" value:"false" usage:"if true, controller will auto free and apply resource while work running"`
 	ResIdleSecsForFree int  `json:"res_idle_secs_for_free" value:"120" usage:"controller free resource while detect resource has been idle over this"`
+
+	SendCork bool `json:"send_cork" value:"false" usage:"if true, controller will send files like tcp cork"`
 }
 
 // CertConfig  configuration of Cert

--- a/src/backend/booster/bk_dist/controller/pkg/api/v1/sdk.go
+++ b/src/backend/booster/bk_dist/controller/pkg/api/v1/sdk.go
@@ -221,10 +221,16 @@ func (s *sdk) launchServer() error {
 		autoResourceMgr = "--auto_resource_mgr"
 	}
 
+	sendcork := ""
+	if s.config.SendCork {
+		sendcork = "--send_cork"
+	}
+
 	return dcSyscall.RunServer(fmt.Sprintf("%s%s -a=%s -p=%d --log-dir=%s --v=%d --local_slots=%d "+
 		"--local_pre_slots=%d --local_exe_slots=%d --local_post_slots=%d --async_flush %s --remain_time=%d "+
 		"--use_local_cpu_percent=%d %s"+
-		"%s --res_idle_secs_for_free=%d",
+		"%s --res_idle_secs_for_free=%d"+
+		" %s",
 		sudo,
 		ctrlPath,
 		s.config.IP,
@@ -241,6 +247,7 @@ func (s *sdk) launchServer() error {
 		disablefilelock,
 		autoResourceMgr,
 		s.config.ResIdleSecsForFree,
+		sendcork,
 	))
 }
 

--- a/src/backend/booster/bk_dist/controller/pkg/manager/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/manager.go
@@ -554,10 +554,14 @@ func (m *mgr) checkWork(startseconds int64) {
 	// 释放心跳超时的work
 	m.worksPool.cleanHeartbeatTimeout()
 
+	// 屏蔽掉该逻辑，有两个理由：
+	// 		1. 重复Init导致内存泄漏
+	//		2. 该协程执行Init时，有可能globalWork在其它协程中正在被使用，导致未知错误（比如内存越界）
+	//		后续如果有脏数据的情况，需要定位跟进
 	// 每当work pool为空时, 重置一下globalWork, 避免一些脏数据残留
-	if m.worksPool.empty() {
-		m.globalWork.Local().Init()
-	}
+	// if m.worksPool.empty() {
+	// 	m.globalWork.Local().Init()
+	// }
 
 	// 如果works pool空闲超过一定时间, 主动退出controller进程
 	if m.conf.RemainTime >= 0 && m.worksPool.emptyTimeout(time.Duration(m.conf.RemainTime)*time.Second) {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/manager.go
@@ -608,7 +608,7 @@ func (m *mgr) checkNet() {
 }
 
 func (m *mgr) setCommonConfig(config *types.CommonConfig) error {
-	blog.Infof("mgr: try to set common config: %+v", *config)
+	blog.Infof("mgr: try to set common config")
 
 	if err := m.saveCommonConfig(config); err != nil {
 		blog.Infof("mgr: failed to save common config with error: %v", err)

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -742,7 +742,7 @@ func (m *Mgr) checkOrLockSendFile(server string, desc dcSDK.FileDesc) (types.Fil
 
 	defer func() {
 		if d2 := time.Now().Local().Sub(t2); d2 > 50*time.Millisecond {
-			blog.Infof("check cache process wait too long server(%s): %s", server, d2.String())
+			blog.Debugf("check cache process wait too long server(%s): %s", server, d2.String())
 		}
 	}()
 

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -1371,14 +1371,17 @@ func (m *Mgr) sendFilesWithCorkSameHost(files []*corkFile) {
 
 	// add retry here
 	var result *dcSDK.BKSendFileResult
+	waitsecs := 5
 	var err error
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		result, err = handler.ExecuteSendFile(host, req, sandbox)
 		if err == nil {
 			break
 		} else {
 			blog.Warnf("remote: failed to send cork %d files with size:%d to server:%s for the %dth times with error:%v",
 				len(files), totalsize, host.Server, i, err)
+			time.Sleep(time.Duration(waitsecs) * time.Second)
+			waitsecs = waitsecs * 2
 		}
 	}
 

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -41,6 +41,10 @@ func NewMgr(pCtx context.Context, work *types.Work) types.RemoteMgr {
 		fileMessageBank:       newFileMessageBank(),
 		conf:                  work.Config(),
 		resourceCheckTick:     5 * time.Second,
+		sendCorkTick:          10 * time.Millisecond,
+		corkSize:              1024 * 512, // 512KB, it will delay much if too big
+		corkFiles:             make(map[string]*[]*corkFile, 0),
+		memSlot:               newMemorySlot(0),
 	}
 }
 
@@ -56,6 +60,8 @@ type Mgr struct {
 	work         *types.Work
 	resource     *resource
 	remoteWorker dcSDK.RemoteWorker
+
+	memSlot *memorySlot
 
 	checkSendFileTick time.Duration
 
@@ -75,6 +81,12 @@ type Mgr struct {
 	lastUsed          uint64 // only accurate to second now
 	lastApplied       uint64 // only accurate to second now
 	remotejobs        int64  // save job number which using remote worker
+
+	sendCorkTick time.Duration
+	sendCorkChan chan bool
+	corkMutex    sync.RWMutex
+	corkSize     int64
+	corkFiles    map[string]*[]*corkFile
 }
 
 type fileSendMap struct {
@@ -156,6 +168,7 @@ func (fsm *fileSendMap) updateStatus(desc dcSDK.FileDesc, status types.FileSendS
 }
 
 // Init do the initialization for remote manager
+// !! only call once !!
 func (m *Mgr) Init() {
 	blog.Infof("remote: init for work:%s", m.work.ID())
 
@@ -170,11 +183,18 @@ func (m *Mgr) Init() {
 
 	m.resource.Handle(ctx)
 
+	m.memSlot.Handle(ctx)
+
 	// register call back for resource changed
 	m.work.Resource().RegisterCallback(m.callback4ResChanged)
 
 	if m.conf.AutoResourceMgr {
 		go m.resourceCheck(ctx)
+	}
+
+	if m.conf.SendCork {
+		m.sendCorkChan = make(chan bool, 1000)
+		go m.sendFilesWithCorkTick(ctx)
 	}
 }
 
@@ -191,6 +211,8 @@ func (m *Mgr) callback4ResChanged() error {
 	// if all workers released, we shoud clean the cache now
 	if hl == nil || len(hl) == 0 {
 		m.cleanFileCache()
+
+		// TODO : do other cleans here
 	}
 	return nil
 }
@@ -205,6 +227,10 @@ func (m *Mgr) cleanFileCache() {
 	m.fileCollectionSendMutex.Lock()
 	m.fileCollectionSendMap = make(map[string]*[]*types.FileCollectionInfo)
 	m.fileCollectionSendMutex.Unlock()
+
+	m.corkMutex.Lock()
+	m.corkFiles = make(map[string]*[]*corkFile, 0)
+	m.corkMutex.Unlock()
 }
 
 func (m *Mgr) setLastUsed(v uint64) {
@@ -515,7 +541,7 @@ func (m *Mgr) ensureFiles(
 				err <- m.ensureSingleFile(handler, host, req, sandbox)
 				d := time.Now().Local().Sub(t)
 				if d > 200*time.Millisecond {
-					blog.Infof("remote: single file cost time for work(%s) from pid(%d) to server(%s): %s, %s",
+					blog.Debugf("remote: single file cost time for work(%s) from pid(%d) to server(%s): %s, %s",
 						m.work.ID(), pid, host.Server, d.String(), req.Files[0].FilePath)
 				}
 			}(wg, s, sender)
@@ -528,7 +554,7 @@ func (m *Mgr) ensureFiles(
 				_ = m.ensureSingleFile(handler, host, req, sandbox)
 				d := time.Now().Local().Sub(t)
 				if d > 200*time.Millisecond {
-					blog.Infof("remote: single file cost time for work(%s) from pid(%d) to server(%s): %s, %s",
+					blog.Debugf("remote: single file cost time for work(%s) from pid(%d) to server(%s): %s, %s",
 						m.work.ID(), pid, host.Server, d.String(), req.Files[0].FilePath)
 				}
 			}(s, sender)
@@ -596,6 +622,19 @@ func (m *Mgr) ensureSingleFile(
 	if m.checkSingleCache(handler, host, desc, sandbox) {
 		m.updateSendFile(host.Server, desc, types.FileSendSucceed)
 		return nil
+	}
+
+	// send like tcp cork
+	if m.conf.SendCork {
+		retcode, err := m.sendFileWithCork(handler, &desc, host, sandbox)
+		if err != nil || retcode != 0 {
+			blog.Warnf("remote: execute send cork file(%s) for work(%s) to server(%s) failed: %v, retcode:%d",
+				desc.FilePath, m.work.ID(), host.Server, err, retcode)
+		} else {
+			blog.Debugf("remote: execute send cork file(%s) for work(%s) to server(%s) succeed",
+				desc.FilePath, m.work.ID(), host.Server)
+			return nil
+		}
 	}
 
 	blog.Debugf("remote: try to ensure single file(%s) for work(%s) to server(%s), going to send this file",
@@ -1178,4 +1217,187 @@ func (m *Mgr) updateToolChainPath(req *types.RemoteTaskExecuteRequest) error {
 		}
 	}
 	return nil
+}
+
+type corkFileResult struct {
+	retcode int32
+	err     error
+}
+
+type corkFile struct {
+	handler    dcSDK.RemoteWorkerHandler
+	host       *dcProtocol.Host
+	sandbox    *dcSyscall.Sandbox
+	file       *dcSDK.FileDesc
+	resultchan chan corkFileResult
+}
+
+func (m *Mgr) sendFileWithCork(handler dcSDK.RemoteWorkerHandler,
+	f *dcSDK.FileDesc,
+	host *dcProtocol.Host,
+	sandbox *dcSyscall.Sandbox) (int32, error) {
+	cf := corkFile{
+		handler:    handler,
+		host:       host,
+		sandbox:    sandbox,
+		file:       f,
+		resultchan: make(chan corkFileResult, 1),
+	}
+
+	// append to file queue
+	m.corkMutex.Lock()
+	if l, ok := m.corkFiles[host.Server]; ok {
+		*l = append(*l, &cf)
+	} else {
+		newl := []*corkFile{&cf}
+		m.corkFiles[host.Server] = &newl
+	}
+	m.corkMutex.Unlock()
+
+	// notify send
+	m.sendCorkChan <- true
+
+	// wait for result
+	msg := <-cf.resultchan
+	return msg.retcode, msg.err
+}
+
+func (m *Mgr) getCorkFiles(getall bool) []*[]*corkFile {
+	m.corkMutex.Lock()
+	defer m.corkMutex.Unlock()
+
+	result := make([]*[]*corkFile, 0)
+	for _, v := range m.corkFiles {
+		// srcfiles := *v
+		var totalsize int64
+		index := -1
+		if getall {
+			index = len(*v) - 1
+		} else {
+			for index, _ = range *v {
+				totalsize += (*v)[index].file.FileSize
+				if totalsize > m.corkSize {
+					break
+				}
+			}
+		}
+
+		if index >= 0 {
+			if totalsize > m.corkSize || getall {
+				// get files
+				num := index + 1
+				start := 0
+				dstfiles := make([]*corkFile, num)
+				copy(dstfiles, (*v)[start:start+num])
+
+				// remove files
+				if num < len(*v) {
+					*v = (*v)[start+num:]
+				} else {
+					*v = make([]*corkFile, 0)
+				}
+
+				result = append(result, &dstfiles)
+			}
+		}
+	}
+
+	return result
+}
+
+func (m *Mgr) sendFilesWithCorkTick(ctx context.Context) {
+	blog.Infof("remote: start send files with cork tick for work: %s", m.work.ID())
+	ticker := time.NewTicker(m.sendCorkTick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			blog.Infof("remote: run send files with cork for work(%s) canceled by context", m.work.ID())
+			return
+
+		case <-ticker.C:
+			// check whether have files to send
+			files := m.getCorkFiles(true)
+			if len(files) > 0 {
+				m.sendFilesWithCork(files)
+			}
+		case <-m.sendCorkChan:
+			// check whether enought files to send
+			files := m.getCorkFiles(false)
+			if len(files) > 0 {
+				m.sendFilesWithCork(files)
+			}
+		}
+	}
+}
+
+func (m *Mgr) sendFilesWithCork(files []*[]*corkFile) {
+	for _, v := range files {
+		if v != nil && len(*v) > 0 {
+			go m.sendFilesWithCorkSameHost(*v)
+		}
+	}
+}
+
+func (m *Mgr) sendFilesWithCorkSameHost(files []*corkFile) {
+
+	var totalsize int64
+	req := &dcSDK.BKDistFileSender{}
+	for _, v := range files {
+		req.Files = append(req.Files, *v.file)
+		totalsize += v.file.FileSize
+	}
+	host := files[0].host
+	sandbox := files[0].sandbox
+	handler := files[0].handler
+
+	blog.Infof("remote: start send %d files with cork to server %s tick for work: %s", len(files), host.Server, m.work.ID())
+
+	// in queue to limit total size of sending files, maybe we should deal if failed
+	// blog.Infof("remote: try to get memory lock with file size:%d", totalsize)
+	if m.memSlot.Lock(totalsize) {
+		// blog.Infof("remote: succeed to get memory lock with file size:%d", totalsize)
+		defer func() {
+			m.memSlot.Unlock(totalsize)
+			// total, occu := m.memSlot.GetStatus()
+			// blog.Infof("remote: succeed to free memory lock with file size:%d,occupy:%d, total:%d", totalsize, occu, total)
+		}()
+	} else {
+		blog.Infof("remote: failed to get memory lock with file size:%d", totalsize)
+	}
+
+	// add retry here
+	var result *dcSDK.BKSendFileResult
+	var err error
+	for i := 0; i < 3; i++ {
+		result, err = handler.ExecuteSendFile(host, req, sandbox)
+		if err == nil {
+			break
+		}
+	}
+
+	status := types.FileSendSucceed
+	if err != nil {
+		status = types.FileSendFailed
+	}
+
+	var retcode int32
+	if err != nil {
+		retcode = -1
+	} else {
+		retcode = result.Results[0].RetCode
+	}
+	resultchan := corkFileResult{
+		retcode: retcode,
+		err:     err,
+	}
+
+	for _, v := range files {
+		m.updateSendFile(host.Server, *v.file, status)
+		v.resultchan <- resultchan
+	}
+
+	blog.Infof("remote: end send %d files with cork to server %s tick for work: %s with err:%v, retcode:%d",
+		len(files), host.Server, m.work.ID(), err, retcode)
 }

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -1274,7 +1274,7 @@ func (m *Mgr) getCorkFiles(getall bool) []*[]*corkFile {
 		if getall {
 			index = len(*v) - 1
 		} else {
-			for index, _ = range *v {
+			for index = range *v {
 				totalsize += (*v)[index].file.FileSize
 				if totalsize > m.corkSize {
 					break

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/slots.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/slots.go
@@ -12,11 +12,13 @@ package remote
 import (
 	"container/list"
 	"context"
+	"runtime"
 	"sync"
 
 	dcProtocol "github.com/Tencent/bk-ci/src/booster/bk_dist/common/protocol"
 	dcSDK "github.com/Tencent/bk-ci/src/booster/bk_dist/common/sdk"
 	"github.com/Tencent/bk-ci/src/booster/common/blog"
+	"github.com/shirou/gopsutil/mem"
 )
 
 type lockWorkerMessage struct {
@@ -442,4 +444,158 @@ func (wr *worker) occupySlot() error {
 func (wr *worker) freeSlot() error {
 	wr.occupiedSlots--
 	return nil
+}
+
+// by tming to limit local memory usage
+func newMemorySlot(maxSlots int64) *memorySlot {
+	minmemroy := int64(2 * 1024 * 1024 * 1024) // 2GB
+
+	if maxSlots <= 0 {
+		v, err := mem.VirtualMemory()
+		if err != nil {
+			maxSlots = int64((runtime.NumCPU() - 2)) * 1024 * 1024 * 1024
+		} else {
+			maxSlots = int64(v.Total) - minmemroy
+		}
+	}
+
+	if maxSlots < minmemroy {
+		maxSlots = minmemroy
+	}
+
+	blog.Infof("memory slot: set max local memory:%d", maxSlots)
+
+	waitingList := list.New()
+
+	return &memorySlot{
+		totalSlots:    maxSlots,
+		occupiedSlots: 0,
+
+		lockChan:   make(chanChanPair, 1000),
+		unlockChan: make(chanChanPair, 1000),
+
+		waitingList: waitingList,
+	}
+}
+
+type chanResult chan struct{}
+
+type chanPair struct {
+	result chanResult
+	weight int64
+}
+
+type chanChanPair chan chanPair
+
+type memorySlot struct {
+	ctx context.Context
+
+	totalSlots    int64
+	occupiedSlots int64
+
+	lockChan   chanChanPair
+	unlockChan chanChanPair
+
+	handling bool
+
+	waitingList *list.List
+}
+
+// brings handler up and begin to handle requests
+func (lr *memorySlot) Handle(ctx context.Context) {
+	if lr.handling {
+		return
+	}
+
+	lr.handling = true
+
+	go lr.handleLock(ctx)
+}
+
+// GetStatus get current slots status
+func (lr *memorySlot) GetStatus() (int64, int64) {
+	return lr.totalSlots, lr.occupiedSlots
+}
+
+// Lock get an usage lock, success with true, failed with false
+func (lr *memorySlot) Lock(weight int64) bool {
+	if !lr.handling {
+		return false
+	}
+
+	msg := chanPair{weight: weight, result: make(chanResult, 1)}
+	lr.lockChan <- msg
+
+	select {
+	case <-lr.ctx.Done():
+		return false
+
+	// wait result
+	case <-msg.result:
+		return true
+	}
+}
+
+// Unlock release an usage lock
+func (lr *memorySlot) Unlock(weight int64) {
+	if !lr.handling {
+		return
+	}
+
+	msg := chanPair{weight: weight, result: nil}
+	lr.unlockChan <- msg
+}
+
+func (lr *memorySlot) handleLock(ctx context.Context) {
+	lr.ctx = ctx
+
+	for {
+		select {
+		case <-ctx.Done():
+			lr.handling = false
+			return
+		case pairChan := <-lr.unlockChan:
+			lr.putSlot(pairChan)
+		case pairChan := <-lr.lockChan:
+			lr.getSlot(pairChan)
+		}
+	}
+}
+
+func (lr *memorySlot) getSlot(pairChan chanPair) {
+	// blog.Infof("memory slot: before get slot occpy size:%d,total size:%d,wait length:%d", lr.occupiedSlots, lr.totalSlots, lr.waitingList.Len())
+
+	if lr.occupiedSlots < lr.totalSlots {
+		lr.occupiedSlots += pairChan.weight
+		pairChan.result <- struct{}{}
+	} else {
+		lr.waitingList.PushBack(pairChan)
+	}
+
+	// blog.Infof("memory slot: after get slot occpy size:%d,total size:%d,wait length:%d", lr.occupiedSlots, lr.totalSlots, lr.waitingList.Len())
+}
+
+func (lr *memorySlot) putSlot(pairChan chanPair) {
+	// blog.Infof("memory slot: before put slot occpy size:%d,total size:%d,wait length:%d", lr.occupiedSlots, lr.totalSlots, lr.waitingList.Len())
+
+	lr.occupiedSlots -= pairChan.weight
+	if lr.occupiedSlots < 0 {
+		lr.occupiedSlots = 0
+	}
+
+	for lr.occupiedSlots < lr.totalSlots && lr.waitingList.Len() > 0 {
+		e := lr.waitingList.Front()
+		if e != nil {
+			tempchan := e.Value.(chanPair)
+			lr.occupiedSlots += tempchan.weight
+
+			// awake this task
+			tempchan.result <- struct{}{}
+
+			// delete this element
+			lr.waitingList.Remove(e)
+		}
+	}
+
+	// blog.Infof("memory slot: after put slot occpy size:%d,total size:%d,wait length:%d", lr.occupiedSlots, lr.totalSlots, lr.waitingList.Len())
 }

--- a/src/backend/booster/bk_dist/controller/pkg/manager/resource/res.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/resource/res.go
@@ -82,7 +82,7 @@ func (r *Res) canRelease() bool {
 	return r.status == ResourceApplying ||
 		r.status == ResourceApplySucceed ||
 		r.status == ResourceReleaseFailed ||
-		r.status == ResourceApplyFailed // https://git.woa.com/buildfast/BuildBooster/issues/510
+		r.status == ResourceApplyFailed
 }
 
 func (r *Res) isReleaseStatus() bool {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/resource/res.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/resource/res.go
@@ -79,7 +79,10 @@ func (r *Res) needHeartBeat() bool {
 }
 
 func (r *Res) canRelease() bool {
-	return r.status == ResourceApplying || r.status == ResourceApplySucceed || r.status == ResourceReleaseFailed
+	return r.status == ResourceApplying ||
+		r.status == ResourceApplySucceed ||
+		r.status == ResourceReleaseFailed ||
+		r.status == ResourceApplyFailed // https://git.woa.com/buildfast/BuildBooster/issues/510
 }
 
 func (r *Res) isReleaseStatus() bool {

--- a/src/backend/booster/bk_dist/handler/ue4/cl/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cl/handler.go
@@ -51,6 +51,7 @@ var (
 		"Module.LuaTools.cpp",
 		"Module.Client.1_of_4.cpp",
 		"Module.HoloLensTargetPlatform.cpp",
+		"msado15.cpp",
 	}
 	// ForceLocalCppFileKeys force some cpp to compile locally
 	DefaultForceLocalCppFileKeys = []string{
@@ -61,6 +62,7 @@ var (
 		"Module.LuaTools.cpp",
 		"Module.Client.1_of_4.cpp",
 		"Module.HoloLensTargetPlatform.cpp",
+		"msado15.cpp",
 	}
 	// DisabledWarnings for ue4 ,disable some warnings
 	DisabledWarnings = []string{"/wd4828"}

--- a/src/backend/booster/bk_dist/handler/ue4/cl/utils.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cl/utils.go
@@ -498,8 +498,8 @@ var (
 		"/FI":                 true,
 		"/Yu":                 true,
 		"/sourceDependencies": true,
-		"/external:":          true, //specify compiler diagnostic behavior for certain header files
-		"-external:":          true, //specify compiler diagnostic behavior for certain header files
+		"/external:I":         true, //specify compiler diagnostic behavior for certain header files
+		"-external:I":         true, //specify compiler diagnostic behavior for certain header files
 	}
 
 	// skip options without value
@@ -512,18 +512,18 @@ var (
 
 	// skip options start with flags
 	skipLocalOptionStartWith = map[string]bool{
-		"/D":         true,
-		"/I":         true,
-		"-D":         true,
-		"-I":         true,
-		"/U":         true,
-		"/Fd":        true,
-		"/FI":        true, // Preprocesses the specified include file.
-		"/Fp":        true, // Preprocesses the specified include file.
-		"/Yu":        true, // Uses a precompiled header file during build.
-		"/Zm":        true, // Specifies the precompiled header memory allocation limit.
-		"/external:": true, //specify compiler diagnostic behavior for certain header files
-		"-external:": true, //specify compiler diagnostic behavior for certain header files
+		"/D":          true,
+		"/I":          true,
+		"-D":          true,
+		"-I":          true,
+		"/U":          true,
+		"/Fd":         true,
+		"/FI":         true, // Preprocesses the specified include file.
+		"/Fp":         true, // Preprocesses the specified include file.
+		"/Yu":         true, // Uses a precompiled header file during build.
+		"/Zm":         true, // Specifies the precompiled header memory allocation limit.
+		"/external:W": true, //specify compiler diagnostic behavior for certain header files
+		"-external:W": true, //specify compiler diagnostic behavior for certain header files
 	}
 )
 

--- a/src/backend/booster/bk_dist/handler/ue4/cl/utils.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cl/utils.go
@@ -11,6 +11,7 @@ package cl
 
 import (
 	"bufio"
+	"crypto/md5"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -252,6 +253,110 @@ func replaceWithNextExclude(s string, old byte, new string, nextExcludes []byte)
 	}
 
 	return string(targetslice)
+}
+
+// ensure compiler exist in args.
+func ensureCompilerRaw(args []string, workdir string) (string, []string, bool, string, string, string, error) {
+	responseFile := ""
+	sourcedependfile := ""
+	objectfile := ""
+	pchfile := ""
+	showinclude := false
+	if len(args) == 0 {
+		blog.Warnf("cl: ensure compiler got empty arg")
+		return responseFile, nil, showinclude, sourcedependfile, objectfile, pchfile, ErrorMissingOption
+	}
+
+	if args[0] == "/" || args[0] == "@" || isSourceFile(args[0]) || isObjectFile(args[0]) {
+		return responseFile, append([]string{defaultCompiler}, args...), showinclude, sourcedependfile, objectfile, pchfile, nil
+	}
+
+	if !strings.HasSuffix(args[0], defaultCompiler) {
+		return responseFile, nil, showinclude, sourcedependfile, objectfile, pchfile, fmt.Errorf("not supported cmd %s", args[0])
+	}
+
+	for _, v := range args {
+		if strings.HasPrefix(v, "@") {
+			responseFile = strings.Trim(v[1:], "\"")
+
+			data := ""
+			if responseFile != "" {
+				var err error
+				data, err = readResponse(responseFile, workdir)
+				if err != nil {
+					blog.Infof("cl: failed to read response file:%s,err:%v", responseFile, err)
+					return responseFile, nil, showinclude, sourcedependfile, objectfile, pchfile, err
+				}
+			}
+			// options, sources, err := parseArgument(data)
+			options, err := shlex.Split(replaceWithNextExclude(string(data), '\\', "\\\\", []byte{'"'}))
+			if err != nil {
+				blog.Infof("cl: failed to parse response file:%s,err:%v", responseFile, err)
+				return responseFile, nil, showinclude, sourcedependfile, objectfile, pchfile, err
+			}
+
+			args = []string{args[0]}
+			args = append(args, options...)
+
+		} else if v == "/showIncludes" {
+			showinclude = true
+		}
+	}
+
+	// if showinclude {
+	// 	args = append(args, "/showIncludes")
+	// }
+
+	for i := range args {
+		if args[i] == "/sourceDependencies" && i+1 <= len(args)-1 {
+			sourcedependfile = args[i+1]
+			continue
+		} else if strings.HasPrefix(args[i], "/Fo") {
+			if len(args[i]) > 3 {
+				objectfile = args[i][3:]
+				continue
+			}
+
+			i++
+			if i >= len(args) {
+				blog.Warnf("cl: scan args: no output file found after /Fo")
+				return responseFile, nil, showinclude, sourcedependfile, objectfile, pchfile, ErrorMissingOption
+			}
+			objectfile = args[i]
+		} else if strings.HasPrefix(args[i], "/Fp") {
+			if len(args[i]) > 3 {
+				pchfile = args[i][3:]
+				continue
+			}
+
+			i++
+			if i >= len(args) {
+				blog.Warnf("cl: scan args: no output file found after /Fo")
+				return responseFile, nil, showinclude, sourcedependfile, objectfile, pchfile, ErrorMissingOption
+			}
+			pchfile = args[i]
+		}
+	}
+
+	// TODO : deal with "/sourceDependencies"
+
+	if responseFile != "" && !filepath.IsAbs(responseFile) {
+		responseFile, _ = filepath.Abs(filepath.Join(workdir, responseFile))
+	}
+
+	if sourcedependfile != "" && !filepath.IsAbs(sourcedependfile) {
+		sourcedependfile, _ = filepath.Abs(filepath.Join(workdir, sourcedependfile))
+	}
+
+	if objectfile != "" && !filepath.IsAbs(objectfile) {
+		objectfile, _ = filepath.Abs(filepath.Join(workdir, objectfile))
+	}
+
+	if pchfile != "" && !filepath.IsAbs(pchfile) {
+		pchfile, _ = filepath.Abs(filepath.Join(workdir, pchfile))
+	}
+
+	return responseFile, args, showinclude, sourcedependfile, objectfile, pchfile, nil
 }
 
 // ensure compiler exist in args.
@@ -499,7 +604,7 @@ type ccArgs struct {
 
 // scanArgs receive the complete compiling args, and the first item should always be a compiler name.
 func scanArgs(args []string) (*ccArgs, error) {
-	blog.Infof("cl: scanning arguments: %v", args)
+	blog.Debugf("cl: scanning arguments: %v", args)
 
 	if len(args) == 0 || strings.HasPrefix(args[0], "/") {
 		blog.Warnf("cl: scan args: unrecognized option: %s", args[0])
@@ -646,7 +751,7 @@ func scanArgs(args []string) (*ccArgs, error) {
 	}
 
 	r.args = args
-	blog.Infof("cl: success to scan arguments: %s, input file %s, output file %s",
+	blog.Debugf("cl: success to scan arguments: %s, input file %s, output file %s",
 		r.args, r.inputFile, r.outputFile)
 	return r, nil
 }
@@ -699,6 +804,34 @@ func makeTmpFile(tmpDir, prefix, ext string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cl: create tmp file failed: %s", target)
+}
+
+func getPumpIncludeFile(tmpDir, prefix, ext string, args []string) (string, error) {
+	fullarg := strings.Join(args, " ")
+	md5str := md5.Sum([]byte(fullarg))
+	target := filepath.Join(tmpDir, fmt.Sprintf("%s_%x%s", prefix, md5str, ext))
+
+	return target, nil
+}
+
+func createFile(target string) error {
+	for i := 0; i < 3; i++ {
+		f, err := os.Create(target)
+		if err != nil {
+			blog.Errorf("cl: failed to create tmp file \"%s\": %s", target, err)
+			continue
+		}
+
+		if err = f.Close(); err != nil {
+			blog.Errorf("cl: failed to close tmp file \"%s\": %s", target, err)
+			return err
+		}
+
+		blog.Infof("cl: success to make tmp file \"%s\"", target)
+		return nil
+	}
+
+	return fmt.Errorf("cl: create tmp file failed: %s", target)
 }
 
 // only genegerate file name, do not create really

--- a/src/backend/booster/bk_dist/handler/ue4/clfilter/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/clfilter/handler.go
@@ -13,6 +13,7 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	dcFile "github.com/Tencent/bk-ci/src/booster/bk_dist/common/file"
@@ -205,6 +206,7 @@ func (cf *TaskCLFilter) postExecute(r *dcSDK.BKDistResult) error {
 	}
 
 	r.Results[0].OutputMessage = []byte(output)
+	blog.Debugf("cf: after parse ouput [%s] for: %v", r.Results[0].OutputMessage, cf.originArgs)
 	return nil
 }
 
@@ -224,10 +226,22 @@ func (cf *TaskCLFilter) parseOutput(s string) (string, error) {
 		}
 
 		// Process the line here.
+		// Note: including file: Runtime\Core\Public\HAL/ThreadHeartBeat.h
+		// Note: including file:     C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\INCLUDE\sal.h
 		columns := strings.Split(line, ":")
-		if len(columns) != 4 {
-			output = append(output, line)
-		} else {
+		if len(columns) == 3 {
+			includefile := strings.Trim(columns[2], " \r\n")
+			if !filepath.IsAbs(includefile) {
+				includefile, _ = filepath.Abs(filepath.Join(cf.sandbox.Dir, includefile))
+			}
+			existed, _, _, _ := dcFile.Stat(includefile).Batch()
+			if existed {
+				includes = append(includes, includefile)
+			} else {
+				blog.Infof("cf: includefile [%s] not existed", includefile)
+				output = append(output, line)
+			}
+		} else if len(columns) == 4 {
 			includefile := columns[2] + ":" + columns[3]
 			includefile = strings.Trim(includefile, " \r\n")
 			existed, _, _, _ := dcFile.Stat(includefile).Batch()
@@ -237,6 +251,8 @@ func (cf *TaskCLFilter) parseOutput(s string) (string, error) {
 				blog.Infof("cf: includefile [%s] not existed", includefile)
 				output = append(output, line)
 			}
+		} else {
+			output = append(output, line)
 		}
 
 		if err != nil {

--- a/src/backend/booster/bk_dist/handler/ue4/shader/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/shader/handler.go
@@ -129,9 +129,10 @@ func (u *UE4Shader) PreExecute(command []string) (*dcSDK.BKDistCommand, error) {
 		}
 	}
 
-	existed, fileSize, modifyTime, fileMode := dcFile.Stat(inputFile).Batch()
+	info := dcFile.Stat(inputFile)
+	existed, fileSize, modifyTime, fileMode := info.Batch()
 	if !existed {
-		return nil, fmt.Errorf("shader: input file %s not exist", inputFile)
+		return nil, fmt.Errorf("shader: input file %s not exist with error:%v", inputFile, info.Error())
 	}
 
 	inputfiles := []dcSDK.FileDesc{{

--- a/src/backend/booster/bk_dist/handler/ue4/shader/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/shader/handler.go
@@ -129,7 +129,6 @@ func (u *UE4Shader) PreExecute(command []string) (*dcSDK.BKDistCommand, error) {
 		}
 	}
 
-	// issue: https://git.woa.com/buildfast/BuildBooster/issues/500
 	info := dcFile.Stat(inputFile)
 	existed, fileSize, modifyTime, fileMode := info.Batch()
 	if !existed {

--- a/src/backend/booster/bk_dist/handler/ue4/shader/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/shader/handler.go
@@ -129,6 +129,7 @@ func (u *UE4Shader) PreExecute(command []string) (*dcSDK.BKDistCommand, error) {
 		}
 	}
 
+	// issue: https://git.woa.com/buildfast/BuildBooster/issues/500
 	info := dcFile.Stat(inputFile)
 	existed, fileSize, modifyTime, fileMode := info.Batch()
 	if !existed {

--- a/src/backend/booster/bk_dist/ubttool/pkg/executor.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/executor.go
@@ -10,6 +10,7 @@
 package pkg
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"runtime"
@@ -88,37 +89,63 @@ func (d *Executor) runWork(fullargs []string, workdir string) (int, error) {
 
 	if len(r.Stdout) > 0 {
 		d.outputmsg = r.Stdout
+		hasNewline := bytes.HasSuffix(r.Stdout, []byte("\n"))
 		// https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
 		// 65001 means utf8, we will try convert to gbk which is not utf8
 		if charcode > 0 && charcode != 65001 {
 			// fmt.Printf("get charset code:%d\n", dcSyscall.GetConsoleCP())
 			gbk, err := dcUtil.Utf8ToGbk(r.Stdout)
 			if err == nil {
-				_, _ = fmt.Fprint(os.Stdout, string(gbk))
+				if hasNewline {
+					_, _ = fmt.Fprintf(os.Stdout, "%s", string(gbk))
+				} else {
+					_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(gbk))
+				}
 			} else {
-				_, _ = fmt.Fprint(os.Stdout, string(r.Stdout))
-				// _, _ = fmt.Fprint(os.Stdout, "errro:%v\n", err)
+				if hasNewline {
+					_, _ = fmt.Fprintf(os.Stdout, "%s", string(r.Stdout))
+				} else {
+					_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(r.Stdout))
+				}
+				// _, _ = fmt.Fprintf(os.Stdout, "errro:%v\n", err)
 			}
 		} else {
-			_, _ = fmt.Fprint(os.Stdout, string(r.Stdout))
+			if hasNewline {
+				_, _ = fmt.Fprintf(os.Stdout, "%s", string(r.Stdout))
+			} else {
+				_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(r.Stdout))
+			}
 		}
 	}
 
 	if len(r.Stderr) > 0 {
 		d.errormsg = r.Stderr
+		hasNewline := bytes.HasSuffix(r.Stderr, []byte("\n"))
 		// https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
 		// 65001 means utf8, we will try convert to gbk which is not utf8
 		if charcode > 0 && charcode != 65001 {
 			// fmt.Printf("get charset code:%d\n", dcSyscall.GetConsoleCP())
 			gbk, err := dcUtil.Utf8ToGbk(r.Stderr)
 			if err == nil {
-				_, _ = fmt.Fprint(os.Stderr, string(gbk))
+				if hasNewline {
+					_, _ = fmt.Fprintf(os.Stderr, "%s", string(gbk))
+				} else {
+					_, _ = fmt.Fprintf(os.Stderr, "%s\n", string(gbk))
+				}
 			} else {
-				_, _ = fmt.Fprint(os.Stderr, string(r.Stderr))
+				if hasNewline {
+					_, _ = fmt.Fprintf(os.Stderr, "%s", string(r.Stderr))
+				} else {
+					_, _ = fmt.Fprintf(os.Stderr, "%s\n", string(r.Stderr))
+				}
 				// _, _ = fmt.Fprint(os.Stderr, "errro:%v\n", err)
 			}
 		} else {
-			_, _ = fmt.Fprint(os.Stderr, string(r.Stderr))
+			if hasNewline {
+				_, _ = fmt.Fprintf(os.Stderr, "%s", string(r.Stderr))
+			} else {
+				_, _ = fmt.Fprintf(os.Stderr, "%s\n", string(r.Stderr))
+			}
 		}
 	}
 

--- a/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
@@ -215,6 +215,9 @@ func (h *UBTTool) selectActionsToExecute() error {
 
 		h.readyactions[index].Running = true
 		h.runningnumber++
+		_, _ = fmt.Fprintf(os.Stdout, "[bk_ubt_tool] finished:%d,running:%d,total:%d, current action: %s %s\n",
+			h.finishednumber, h.runningnumber, len(h.allactions),
+			h.readyactions[index].Cmd, h.readyactions[index].Arg)
 		go h.executeOneAction(h.readyactions[index], h.actionchan)
 	}
 

--- a/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
@@ -13,7 +13,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -156,7 +158,7 @@ func (h *UBTTool) executeActions() error {
 
 	fmt.Fprintf(os.Stderr, "UBTTool: Building %d actions with %d jobs...", len(h.allactions), h.maxjobs)
 
-	h.dump()
+	// h.dump()
 
 	// execute actions no more than max jobs
 	blog.Infof("UBTTool: try to run actions with %d jobs", h.maxjobs)
@@ -198,9 +200,44 @@ func (h *UBTTool) executeActions() error {
 				blog.Errorf("UBTTool: faile to execute actions with error:%v", ErrorOverMaxTime)
 				return ErrorOverMaxTime
 			}
-			h.dump()
+			// h.dump()
 		}
 	}
+}
+
+// issue: https://git.woa.com/buildfast/BuildBooster/issues/503
+// to simply print log
+func getActionDesc(cmd, arg string) string {
+	// _, _ = fmt.Fprintf(os.Stdout, "cmd %s arg %s\n", cmd, arg)
+
+	exe := filepath.Base(cmd)
+	targetsuffix := []string{}
+	switch exe {
+	case "cl.exe", "cl-filter.exe", "clang.exe", "clang++.exe", "clang", "clang++":
+		targetsuffix = []string{".cpp", ".c", ".response\"", ".response"}
+		break
+	case "lib.exe", "link.exe", "link-filter.exe":
+		targetsuffix = []string{".dll", ".lib", ".response\"", ".response"}
+	default:
+		return exe
+	}
+
+	args, _ := shlex.Split(replaceWithNextExclude(arg, '\\', "\\\\", []byte{'"'}))
+	if len(args) == 1 {
+		argbase := strings.TrimRight(filepath.Base(arg), "\"")
+		return fmt.Sprintf("%s %s", exe, argbase)
+	} else {
+		for _, v := range args {
+			for _, s := range targetsuffix {
+				if strings.HasSuffix(v, s) {
+					vtrime := strings.TrimRight(v, "\"")
+					return fmt.Sprintf("%s %s", exe, vtrime)
+				}
+			}
+		}
+	}
+
+	return exe
 }
 
 func (h *UBTTool) selectActionsToExecute() error {
@@ -215,9 +252,9 @@ func (h *UBTTool) selectActionsToExecute() error {
 
 		h.readyactions[index].Running = true
 		h.runningnumber++
-		_, _ = fmt.Fprintf(os.Stdout, "[bk_ubt_tool] finished:%d,running:%d,total:%d, current action: %s %s\n",
-			h.finishednumber, h.runningnumber, len(h.allactions),
-			h.readyactions[index].Cmd, h.readyactions[index].Arg)
+		_, _ = fmt.Fprintf(os.Stdout, "[bk_ubt_tool] [%d/%d] %s\n",
+			h.finishednumber+h.runningnumber, len(h.allactions),
+			getActionDesc(h.readyactions[index].Cmd, h.readyactions[index].Arg))
 		go h.executeOneAction(h.readyactions[index], h.actionchan)
 	}
 

--- a/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
@@ -205,7 +205,6 @@ func (h *UBTTool) executeActions() error {
 	}
 }
 
-// issue: https://git.woa.com/buildfast/BuildBooster/issues/503
 // to simply print log
 func getActionDesc(cmd, arg string) string {
 	// _, _ = fmt.Fprintf(os.Stdout, "cmd %s arg %s\n", cmd, arg)

--- a/src/backend/booster/bk_dist/worker/pkg/client/bkcommondist_handler.go
+++ b/src/backend/booster/bk_dist/worker/pkg/client/bkcommondist_handler.go
@@ -386,6 +386,8 @@ func (r *CommonRemoteHandler) ExecuteSendFile(
 		}
 	}
 
+	debug.FreeOSMemory() // free memory anyway
+
 	blog.Debugf("success pack-up to server %s", server)
 	// send request
 	dcSDK.StatsTimeNow(&r.recordStats.RemoteWorkSendCommonStartTime)
@@ -396,6 +398,8 @@ func (r *CommonRemoteHandler) ExecuteSendFile(
 		blog.Warnf("error: %v", err)
 		return nil, err
 	}
+
+	debug.FreeOSMemory() // free memory anyway
 
 	blog.Debugf("success sent to server %s", server)
 	// receive result

--- a/src/backend/booster/bk_dist/worker/pkg/client/bkcommondist_protocol.go
+++ b/src/backend/booster/bk_dist/worker/pkg/client/bkcommondist_protocol.go
@@ -290,12 +290,18 @@ func encodeCommonDispatchReq(req *dcSDK.BKDistCommand) ([]protocol.Message, erro
 	// encode body and file to message
 	pbbody := protocol.PBBodyDispatchTaskReq{}
 	for _, v := range req.Commands {
+		envs := [][]byte{}
+		for _, v := range v.Env {
+			envs = append(envs, []byte(v))
+		}
+
 		pbcommand := protocol.PBCommand{
 			Workdir:     &v.WorkDir,
 			Exepath:     &v.ExePath,
 			Exename:     &v.ExeName,
 			Params:      v.Params,
 			Resultfiles: v.ResultFiles,
+			Env:         envs,
 		}
 		if len(v.Inputfiles) > 0 {
 			for _, f := range v.Inputfiles {

--- a/src/backend/booster/bk_dist/worker/pkg/protocol/pb_protocol.go
+++ b/src/backend/booster/bk_dist/worker/pkg/protocol/pb_protocol.go
@@ -399,7 +399,7 @@ func saveFile(
 
 	// compressed size < 0 means do not save, or may will overwrite existing files.
 	if size := rf.GetCompressedsize(); size < 0 {
-		blog.Warnf("get compressed size for [%s] < 0: %d", inputfile, size)
+		blog.Debugf("get compressed size for [%s] < 0: %d", inputfile, size)
 		return inputfile, nil
 	}
 

--- a/src/backend/booster/bk_dist/worker/pkg/protocol/pb_protocol.go
+++ b/src/backend/booster/bk_dist/worker/pkg/protocol/pb_protocol.go
@@ -84,7 +84,7 @@ func fillOneFile(filefullpath string, compresstype protocol.PBCompressType) (pro
 	}
 	data, err := ioutil.ReadFile(filefullpath)
 	if err != nil {
-		blog.Warnf("failed to read file[%s]", filefullpath)
+		blog.Warnf("failed to read file[%s] with err:%v", filefullpath, err)
 		return message, 0, err
 	}
 
@@ -141,7 +141,7 @@ func EncodeBKCommonDispatchRsp(results []*protocol.PBResult) ([]protocol.Message
 			}
 			m, compressedsize, err := fillOneFile(realfile, f.GetCompresstype())
 			if err != nil {
-				blog.Warnf("failed to encode message for file %s", f.GetFullpath())
+				blog.Warnf("failed to encode message for file %s with err:%v", f.GetFullpath(), err)
 				// for this condition, we will set data to 0
 				// continue
 				compressedsize = 0
@@ -179,14 +179,14 @@ func EncodeBKCommonDispatchRsp(results []*protocol.PBResult) ([]protocol.Message
 	}
 	headdata, err := proto.Marshal(&pbhead)
 	if err != nil {
-		blog.Warnf("failed to proto.Marshal pbhead")
+		blog.Warnf("failed to proto.Marshal pbhead with err:%v", err)
 		return nil, err
 	}
 	blog.Infof("encode head to size %d", pbhead.XXX_Size())
 
 	headtokendata, err := formatTokenInt(protocol.TOEKNHEADFLAG, pbhead.XXX_Size())
 	if err != nil {
-		blog.Warnf("failed to format head token")
+		blog.Warnf("failed to format head token with err:%v", err)
 		return nil, err
 	}
 	headtokenmessage := protocol.Message{
@@ -222,7 +222,7 @@ func ReceiveBKCommonHead(client *TCPClient) (*protocol.PBHead, error) {
 	// receive head token
 	data, datalen, err := client.ReadData(protocol.TOKENBUFLEN)
 	if err != nil {
-		blog.Warnf("failed to receive head token")
+		blog.Warnf("failed to receive head token with err:%v", err)
 		return nil, err
 	}
 	blog.Debugf("succeed to recieve head token %s", string(data))
@@ -287,7 +287,7 @@ func ReceiveBKCommonDispatchReq(client *TCPClient,
 	// receive body
 	data, datalen, err := client.ReadData(int(bodylen))
 	if err != nil {
-		blog.Warnf("failed to receive pbbody")
+		blog.Warnf("failed to receive pbbody with err:%v", err)
 		return nil, err
 	}
 
@@ -323,7 +323,7 @@ func receiveBKCommonDispatchReqBuf(client *TCPClient,
 	if buflen >= 0 {
 		data, datalen, err := client.ReadData(int(buflen))
 		if err != nil {
-			blog.Warnf("failed to receive pb buf")
+			blog.Warnf("failed to receive pb buf with err:%v", err)
 			return err
 		}
 
@@ -614,14 +614,14 @@ func EncodeBKSyncTimeRsp(receivedtime time.Time) ([]protocol.Message, error) {
 	}
 	headdata, err := proto.Marshal(&pbhead)
 	if err != nil {
-		blog.Warnf("failed to proto.Marshal pbhead")
+		blog.Warnf("failed to proto.Marshal pbhead with err:%v", err)
 		return nil, err
 	}
 	blog.Infof("encode head to size %d", pbhead.XXX_Size())
 
 	headtokendata, err := formatTokenInt(protocol.TOEKNHEADFLAG, pbhead.XXX_Size())
 	if err != nil {
-		blog.Warnf("failed to format head token")
+		blog.Warnf("failed to format head token with err:%v", err)
 		return nil, err
 	}
 	headtokenmessage := protocol.Message{
@@ -680,14 +680,14 @@ func EncodeBKCheckCacheRsp(result []*protocol.PBCacheResult) ([]protocol.Message
 	}
 	headdata, err := proto.Marshal(&pbhead)
 	if err != nil {
-		blog.Warnf("failed to proto.Marshal pbhead")
+		blog.Warnf("failed to proto.Marshal pbhead with err:%v", err)
 		return nil, err
 	}
 	blog.Infof("encode head to size %d", pbhead.XXX_Size())
 
 	headtokendata, err := formatTokenInt(protocol.TOEKNHEADFLAG, pbhead.XXX_Size())
 	if err != nil {
-		blog.Warnf("failed to format head token")
+		blog.Warnf("failed to format head token with err:%v", err)
 		return nil, err
 	}
 	headtokenmessage := protocol.Message{
@@ -729,14 +729,14 @@ func EncodeBKUnknownRsp(_ time.Time) ([]protocol.Message, error) {
 	}
 	headdata, err := proto.Marshal(&pbhead)
 	if err != nil {
-		blog.Warnf("failed to proto.Marshal pbhead")
+		blog.Warnf("failed to proto.Marshal pbhead with err:%v", err)
 		return nil, err
 	}
 	blog.Infof("encode head to size %d", pbhead.XXX_Size())
 
 	headtokendata, err := formatTokenInt(protocol.TOEKNHEADFLAG, pbhead.XXX_Size())
 	if err != nil {
-		blog.Warnf("failed to format head token")
+		blog.Warnf("failed to format head token with err:%v", err)
 		return nil, err
 	}
 	headtokenmessage := protocol.Message{
@@ -811,7 +811,7 @@ func ReceiveBKSendFile(client *TCPClient,
 	// receive body
 	data, datalen, err := client.ReadData(int(bodylen))
 	if err != nil {
-		blog.Warnf("failed to receive pbbody")
+		blog.Warnf("failed to receive pbbody with err:%v", err)
 		return nil, err
 	}
 
@@ -848,7 +848,7 @@ func receiveBKSendFileBuf(client *TCPClient,
 	if buflen > 0 {
 		data, datalen, err := client.ReadData(int(buflen))
 		if err != nil {
-			blog.Warnf("failed to receive pb buf")
+			blog.Warnf("failed to receive pb buf with err:%v", err)
 			return err
 		}
 
@@ -970,14 +970,14 @@ func EncodeBKSendFileRsp(req *protocol.PBBodySendFileReq) ([]protocol.Message, e
 	}
 	headdata, err := proto.Marshal(&pbhead)
 	if err != nil {
-		blog.Warnf("failed to proto.Marshal pbhead")
+		blog.Warnf("failed to proto.Marshal pbhead with err:%v", err)
 		return nil, err
 	}
 	blog.Infof("encode head to size %d", pbhead.XXX_Size())
 
 	headtokendata, err := formatTokenInt(protocol.TOEKNHEADFLAG, pbhead.XXX_Size())
 	if err != nil {
-		blog.Warnf("failed to format head token")
+		blog.Warnf("failed to format head token with err:%v", err)
 		return nil, err
 	}
 	headtokenmessage := protocol.Message{
@@ -1021,7 +1021,7 @@ func ReceiveBKCheckCache(client *TCPClient,
 	// receive body
 	data, datalen, err := client.ReadData(int(bodylen))
 	if err != nil {
-		blog.Warnf("failed to receive pbbody")
+		blog.Warnf("failed to receive pbbody with err:%v", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
1. 主要是windows下ue的pump模式相关
    pump : 支持将编译的依赖文件找出来，发送到远端，远端直接编译，无需在本地预处理生成预处理文件（.i 或者 .ii）
    pump的cache : 支持将上一步找出来的依赖文件列表缓存到本地
    send cork功能 : 发送依赖列表文件时，不是收到请求后直接发送，而是判断缓冲区大小，或者超时发送
    发送文件的内存slot : 限制同时发送的文件的大小，避免内存过大崩溃

2. bk-ubt-tool有两个改动，一是支持了失败重试，另外就是精简了打印日志