### PR TITLE
bug:流水线取消时，当job还未完全结束时不应立即把流水线model中的job状态置为取消状态 #7536

### DIFF
--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildCancelControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildCancelControl.kt
@@ -121,13 +121,15 @@ class BuildCancelControl @Autowired constructor(
                 setBuildCancelActionRedisFlag(buildId)
             }
             cancelAllPendingTask(event = event, model = model)
-            // 修改detail model
-            pipelineBuildDetailService.buildCancel(
-                projectId = event.projectId,
-                buildId = event.buildId,
-                buildStatus = event.status,
-                cancelUser = event.userId
-            )
+            if (event.actionType == ActionType.TERMINATE) {
+                // 修改detail model
+                pipelineBuildDetailService.buildCancel(
+                    projectId = event.projectId,
+                    buildId = event.buildId,
+                    buildStatus = event.status,
+                    cancelUser = event.userId
+                )
+            }
 
             // 排队的则不再获取Pending Stage，防止Final Stage被执行
             val pendingStage: PipelineBuildStage? =


### PR DESCRIPTION
bug:流水线取消时，当job还未完全结束时不应立即把流水线model中的job状态置为取消状态 #7536
#7536