### PR TITLE
feat:支持bk-dist-controller重启后业务能够继续正常运行,issue: #7876

### DIFF
--- a/src/backend/booster/Makefile
+++ b/src/backend/booster/Makefile
@@ -131,6 +131,10 @@ dist_idle_loop:dist_prepare
 	# bk-idle-loop
 	go build -ldflags "${LDFLAG}" -o ${DISTEXECUTOR_BIN_PATH}/bk-idle-loop ./bk_dist/idleloop/main.go
 
+dist_monitor:dist_prepare
+	# bk-dist-monitor
+	go build -ldflags "${LDFLAG}" -o ${DISTEXECUTOR_BIN_PATH}/bk-dist-monitor ./bk_dist/monitor/main.go
+
 dist_help_tool:dist_prepare
 	# bk-help-tool
 	go build -ldflags "${LDFLAG}" -o ${DISTEXECUTOR_BIN_PATH}/bk-help-tool ./bk_dist/helptool/main.go
@@ -146,7 +150,7 @@ dist_shader_tool:dist_prepare
 dist_hook:dist_prepare
 	cd tools/hook_ld_preload && $(MAKE) all && cp bkhook.so ../../${DISTEXECUTOR_BIN_PATH}/
 
-dist:dist_executor dist_booster dist_controller dist_worker dist_idle_loop dist_help_tool dist_ubt_tool dist_shader_tool dist_hook
+dist:dist_executor dist_booster dist_controller dist_worker dist_idle_loop dist_help_tool dist_ubt_tool dist_shader_tool dist_hook dist_monitor
 
 clean_dist:
 	rm -rf ${DISTEXECUTOR_BIN_PATH}

--- a/src/backend/booster/bk_dist/common/sdk/controller.go
+++ b/src/backend/booster/bk_dist/common/sdk/controller.go
@@ -52,7 +52,8 @@ type ControllerWorkSDK interface {
 // this is working under a single job
 type WorkJob interface {
 	ExecuteRemoteTask(req *BKDistCommand) (*BKDistResult, error)
-	ExecuteLocalTask(commands []string, workdir string) (*LocalTaskResult, error)
+	// return http code / http message / execute result / execute error
+	ExecuteLocalTask(commands []string, workdir string) (int, string, *LocalTaskResult, error)
 	SendRemoteFile2All(req []FileDesc) error
 }
 

--- a/src/backend/booster/bk_dist/common/syscall/syscall_unix.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_unix.go
@@ -116,6 +116,12 @@ func (s *Sandbox) ExecScripts(src string) (int, error) {
 	return s.ExecCommand(caller, options, src)
 }
 
+// ExecScriptsWithMessage run the scripts and return the output
+func (s *Sandbox) ExecScriptsWithMessage(src string) (int, []byte, []byte, error) {
+	caller, options := GetCallerAndOptions()
+	return s.ExecCommandWithMessage(caller, options, src)
+}
+
 // StartScripts run the scripts
 func (s *Sandbox) StartScripts(src string) (*exec.Cmd, error) {
 	caller, options := GetCallerAndOptions()

--- a/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
@@ -158,6 +158,27 @@ func (s *Sandbox) ExecScripts(src string) (int, error) {
 	return s.execCommand(caller)
 }
 
+// ExecScriptsWithMessage run the scripts and return the output
+func (s *Sandbox) ExecScriptsWithMessage(src string) (int, []byte, []byte, error) {
+	caller, options := GetCallerAndOptions()
+
+	s.spa = &syscall.SysProcAttr{
+		CmdLine:    fmt.Sprintf("%s %s", options, src),
+		HideWindow: true,
+	}
+
+	var outBuf, errBuf bytes.Buffer
+	s.Stdout = &outBuf
+	s.Stderr = &errBuf
+
+	code, err := s.execCommand(caller)
+	if err != nil && code != ExitErrorCode && len(errBuf.Bytes()) == 0 {
+		return code, outBuf.Bytes(), []byte(err.Error()), err
+	}
+
+	return code, outBuf.Bytes(), errBuf.Bytes(), err
+}
+
 // StartScripts start the scripts, not wait
 func (s *Sandbox) StartScripts(src string) (*exec.Cmd, error) {
 	caller, options := GetCallerAndOptions()

--- a/src/backend/booster/bk_dist/common/util/util.go
+++ b/src/backend/booster/bk_dist/common/util/util.go
@@ -338,6 +338,28 @@ func ProcessExist(target string) bool {
 	return false
 }
 
+// ListProcess list process by process name
+func ListProcess(target string) ([]*process.Process, error) {
+	processes, err := process.Processes()
+	if err != nil {
+		return nil, err
+	}
+
+	procs := []*process.Process{}
+	for _, p := range processes {
+		name, err := p.Name()
+		if err != nil {
+			continue
+		}
+
+		if target == name {
+			procs = append(procs, p)
+		}
+	}
+
+	return procs, nil
+}
+
 // ProcessExistTimeoutAndKill check target process with name, and kill it after timeout
 func ProcessExistTimeoutAndKill(target string, timeout time.Duration) bool {
 	processes, err := process.Processes()

--- a/src/backend/booster/bk_dist/controller/pkg/api/error.go
+++ b/src/backend/booster/bk_dist/controller/pkg/api/error.go
@@ -38,6 +38,7 @@ const (
 	ServerErrExecuteRemoteTaskFailed
 	ServerErrSendRemoteFileFailed
 	ServerErrExecuteLocalTaskFailed
+	ServerErrWorkNotFound
 )
 
 var serverErrCode = map[ServerErrCode]string{
@@ -66,6 +67,7 @@ var serverErrCode = map[ServerErrCode]string{
 	ServerErrExecuteRemoteTaskFailed:    "execute remote task failed",
 	ServerErrSendRemoteFileFailed:       "send remote file failed",
 	ServerErrExecuteLocalTaskFailed:     "execute local task failed",
+	ServerErrWorkNotFound:               "work not found",
 }
 
 // String get error string from error code

--- a/src/backend/booster/bk_dist/controller/pkg/api/v1/types.go
+++ b/src/backend/booster/bk_dist/controller/pkg/api/v1/types.go
@@ -223,10 +223,10 @@ func (l *LocalTaskExecuteResp) Write2Resp(resp *api.RestResponse) {
 }
 
 // Read parse LocalTaskExecuteResp from http response body
-func (l *LocalTaskExecuteResp) Read(data []byte) error {
+func (l *LocalTaskExecuteResp) Read(data []byte) (int, string, error) {
 	var r PBLocalExecuteResult
 	if err := proto.Unmarshal(data, &r); err != nil {
-		return err
+		return 0, "", err
 	}
 
 	l.Result = &dcSDK.LocalTaskResult{
@@ -236,5 +236,10 @@ func (l *LocalTaskExecuteResp) Read(data []byte) error {
 		Message:  string(r.GetMessage()),
 	}
 
-	return nil
+	return int(r.Basic.GetCode()), string(r.Basic.GetMessage()), nil
+}
+
+type WorkerChanged struct {
+	OldWorkID string `json:"old_work_id"`
+	NewWorkID string `json:"new_work_id"`
 }

--- a/src/backend/booster/bk_dist/controller/pkg/manager/basic/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/basic/mgr.go
@@ -169,6 +169,12 @@ func (m *Mgr) Register(config *types.WorkRegisterConfig) error {
 	return nil
 }
 
+func (m *Mgr) ApplyResource(config *types.WorkRegisterConfig) error {
+	m.applyResource(config)
+
+	return nil
+}
+
 func (m *Mgr) applyResource(config *types.WorkRegisterConfig) {
 	blog.Infof("basic: going to apply resource for work(%s) with project(%s) scene(%s)",
 		m.work.ID(), config.Apply.ProjectID, config.Apply.Scene)
@@ -258,8 +264,11 @@ func (m *Mgr) Start() error {
 	// work正式启动后, 需要初始化一系列manager,
 	// local:  启动本地的持锁队列
 	// remote: 启动远程连接池
-	m.work.Local().Init()
-	m.work.Remote().Init()
+	// change from Init to Start
+	// m.work.Local().Init()
+	// m.work.Remote().Init()
+	m.work.Local().Start()
+	m.work.Remote().Start()
 
 	go m.syncBriefStats()
 	return nil

--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/mgr.go
@@ -58,6 +58,13 @@ type Mgr struct {
 
 // Init do the initialization for local manager
 func (m *Mgr) Init() {
+	blog.Infof("local: init for work:%s", m.work.ID())
+}
+
+// Start start resource slots for local manager
+func (m *Mgr) Start() {
+	blog.Infof("local: start for work:%s", m.work.ID())
+
 	settings := m.work.Basic().Settings()
 	m.resource = newResource(settings.LocalTotalLimit, settings.UsageLimit)
 

--- a/src/backend/booster/bk_dist/controller/pkg/manager/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/manager.go
@@ -93,6 +93,11 @@ func (m *mgr) RegisterWork(config *types.WorkRegisterConfig) (*types.WorkInfo, b
 				work.Basic().IncRegistered()
 				blog.Infof("mgr: success get a existing work(%s) with batch mode for project(%s) scene(%s)",
 					work.ID(), config.Apply.ProjectID, config.Apply.Scene)
+
+				// TOOD : apply resource if need
+				if !work.Resource().HasAvailableWorkers() {
+					work.Basic().ApplyResource(config)
+				}
 				return info, false, nil
 			}
 			work.Unlock()
@@ -848,4 +853,14 @@ func (m *mgr) checkRunWithLocalResource(work *types.Work) bool {
 
 func (m *mgr) decLocalResourceTask() {
 	atomic.AddInt32(&m.localResourceTaskNum, -1)
+}
+
+// Get first workid
+func (m *mgr) GetFirstWorkID() (string, error) {
+	work, err := m.worksPool.getFirstWork()
+	if err == nil {
+		return work.ID(), nil
+	} else {
+		return "", err
+	}
 }

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/slots.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/slots.go
@@ -33,7 +33,8 @@ type usageWorkerSet struct {
 	occupied int
 }
 
-func newResource(hl []*dcProtocol.Host, usageLimit map[dcSDK.JobUsage]int) *resource {
+// func newResource(hl []*dcProtocol.Host, usageLimit map[dcSDK.JobUsage]int) *resource {
+func newResource(hl []*dcProtocol.Host) *resource {
 	wl := make([]*worker, 0, len(hl))
 	total := 0
 	for _, h := range hl {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/works_pool.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/works_pool.go
@@ -80,6 +80,17 @@ func (wp *worksPool) getWork(workID string) (*types.Work, error) {
 	return work, nil
 }
 
+func (wp *worksPool) getFirstWork() (*types.Work, error) {
+	wp.RLock()
+	defer wp.RUnlock()
+
+	for _, work := range wp.works {
+		return work, nil
+	}
+
+	return nil, types.ErrNoWork
+}
+
 func (wp *worksPool) find(projectID, scene string, batchMode bool) *types.Work {
 	wp.RLock()
 	defer wp.RUnlock()

--- a/src/backend/booster/bk_dist/controller/pkg/types/error.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/error.go
@@ -20,6 +20,7 @@ var (
 	ErrHostSlotOverLimit            = fmt.Errorf("host slot over limit")
 	ErrHostNoFound                  = fmt.Errorf("host no found")
 	ErrWorkNoFound                  = fmt.Errorf("work no found")
+	ErrNoWork                       = fmt.Errorf("not any work")
 	ErrNoAvailableHostSlotFound     = fmt.Errorf("no available host slot found")
 	ErrWorkResourceCannotBeSet      = fmt.Errorf("work resource can not be set")
 	ErrWorkSettingsCannotBeSet      = fmt.Errorf("work settings can not be set")

--- a/src/backend/booster/bk_dist/controller/pkg/types/interface.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/interface.go
@@ -81,12 +81,17 @@ type Mgr interface {
 
 	// get caches in pump mode
 	GetPumpCache(workID string) (*analyser.FileCache, *analyser.RootCache, error)
+
+	// Get first workid
+	GetFirstWorkID() (string, error)
 }
 
 // RemoteMgr describe a manager for handling all actions with remote workers for work
 type RemoteMgr interface {
 	// init handler
 	Init()
+
+	Start()
 
 	// run task in remote worker
 	ExecuteTask(req *RemoteTaskExecuteRequest) (*RemoteTaskExecuteResult, error)
@@ -108,6 +113,8 @@ type RemoteMgr interface {
 type LocalMgr interface {
 	// init handler
 	Init()
+
+	Start()
 
 	// lock local slot
 	LockSlots(usage dcSDK.JobUsage, weight int32) bool
@@ -143,6 +150,9 @@ type ResourceMgr interface {
 
 	// send stats, if brief true, then will not send the job stats
 	SendStats(brief bool) error
+
+	// send stats and reset after sent, if brief true, then will not send the job stats
+	SendAndResetStats(brief bool, t int64) error
 
 	// get resource status
 	GetStatus() *v2.RespTaskInfo
@@ -194,6 +204,9 @@ type BasicMgr interface {
 
 	// do register work
 	Register(config *WorkRegisterConfig) error
+
+	// do apply resource
+	ApplyResource(config *WorkRegisterConfig) error
 
 	// do unregister work
 	Unregister(config *WorkUnregisterConfig) error

--- a/src/backend/booster/bk_dist/controller/pkg/types/work.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/work.go
@@ -53,6 +53,11 @@ func NewWork(id string, conf *config.ServerConfig, mgrSet MgrSet, rp *recorder.R
 	work.remote = mgrSet.Remote(ctx, work)
 	work.resource = mgrSet.Resource(ctx, work)
 	work.basic.Info().Init()
+
+	// TODO : work.local need Init also, but it depend basic.Setting
+	work.local.Init()
+	work.remote.Init()
+
 	return work
 }
 

--- a/src/backend/booster/bk_dist/executor/main.go
+++ b/src/backend/booster/bk_dist/executor/main.go
@@ -26,6 +26,6 @@ func main() {
 		ToStdErr: true,
 	})
 
-	exitCode, _ := executor.NewDistExecutor().Run()
+	exitCode, _, _ := executor.NewDistExecutor().Run()
 	os.Exit(exitCode)
 }

--- a/src/backend/booster/bk_dist/idleloop/command/command.go
+++ b/src/backend/booster/bk_dist/idleloop/command/command.go
@@ -20,8 +20,9 @@ import (
 
 // define const vars
 const (
-	FlagArgs = "args"
-	FlagLog  = "log"
+	FlagLog    = "log"
+	FlagLogDir = "log_dir"
+	FlagArgs   = "args"
 )
 
 // Run main entrance
@@ -48,6 +49,10 @@ func GetApp(ct ClientType) *commandCli.App {
 		commandCli.StringFlag{
 			Name:  "log",
 			Usage: "log level to print some information",
+		},
+		commandCli.StringFlag{
+			Name:  "log_dir",
+			Usage: "log dir to save log files",
 		},
 		commandCli.StringFlag{
 			Name:  "args, a",

--- a/src/backend/booster/bk_dist/idleloop/pkg/idleloop.go
+++ b/src/backend/booster/bk_dist/idleloop/pkg/idleloop.go
@@ -27,6 +27,7 @@ func NewIdleLoop() *IdleLoop {
 // IdleLoop 空循环, 目的是保持运行以维持心跳和资源的存在
 type IdleLoop struct {
 	ppid int32
+
 	// bk-booster -> cmd -> bk-idle-loop, so we should care about the pid of bk-booster
 	pppid int32
 }
@@ -37,6 +38,8 @@ func (l *IdleLoop) Run(ctx context.Context) (int, error) {
 }
 
 func (l *IdleLoop) run(pCtx context.Context) (int, error) {
+	defer blog.CloseLogs()
+
 	l.ppid = int32(os.Getppid())
 	p, err := process.NewProcess(l.ppid)
 	if err == nil {

--- a/src/backend/booster/bk_dist/monitor/command/command.go
+++ b/src/backend/booster/bk_dist/monitor/command/command.go
@@ -20,11 +20,10 @@ import (
 
 // define const vars
 const (
-	FlagLog               = "log"
-	FlagLogDir            = "log_dir"
-	FlagActionJSONFile    = "actions_json_file"
-	FlagToolChainJSONFile = "tool_chain_json_file"
-	FlagMostDependFirst   = "most_depend_first"
+	FlagLog       = "log"
+	FlagLogDir    = "log_dir"
+	FlagArgs      = "args"
+	FlagRulesFile = "rules_file"
 )
 
 // Run main entrance
@@ -57,21 +56,17 @@ func GetApp(ct ClientType) *commandCli.App {
 			Usage: "log dir to save log files",
 		},
 		commandCli.StringFlag{
-			Name:  "actions_json_file",
-			Usage: "json file to describe ue4 actions to execute",
+			Name:  "args, a",
+			Usage: "flags and args that will be pass-through",
 		},
 		commandCli.StringFlag{
-			Name:  "tool_chain_json_file",
-			Usage: "json file to describe tool chain",
-		},
-		commandCli.BoolFlag{
-			Name:  "most_depend_first",
-			Usage: "firstly execute actions which depend mostly",
+			Name:  "rules_file, rf",
+			Usage: "rules file to describe monitor rules",
 		},
 	}
 
 	switch ct {
-	case ClientBKUBTTool:
+	case ClientBKDistMonitor:
 		client.Flags = append(client.Flags, []commandCli.Flag{}...)
 
 		client.Action = mainProcess

--- a/src/backend/booster/bk_dist/monitor/command/types.go
+++ b/src/backend/booster/bk_dist/monitor/command/types.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 THL A29 Limited, a Tencent company. All rights reserved
+ *
+ * This source code file is licensed under the MIT License, you may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ */
+
+package command
+
+// ClientType define client type
+type ClientType string
+
+// define vars
+var (
+	ClientBKDistMonitor ClientType = "bk-dist-monitor"
+)
+
+// const vars
+const (
+	ClientBKDistMonitorUsage = "BlueKing dist monitor"
+)
+
+// Name return client name
+func (ct ClientType) Name() string {
+	switch ct {
+	case ClientBKDistMonitor:
+		return string(ct)
+	}
+	return "unknown"
+}
+
+// Usage return client usage
+func (ct ClientType) Usage() string {
+	switch ct {
+	case ClientBKDistMonitor:
+		return ClientBKDistMonitorUsage
+	}
+	return "unknown"
+}

--- a/src/backend/booster/bk_dist/monitor/main.go
+++ b/src/backend/booster/bk_dist/monitor/main.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 THL A29 Limited, a Tencent company. All rights reserved
+ *
+ * This source code file is licensed under the MIT License, you may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/monitor/command"
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/monitor/pkg"
+)
+
+func main() {
+	if !pkg.Lock() {
+		fmt.Printf("exit for other instance is already started")
+		return
+	}
+	defer pkg.Unlock()
+
+	command.Run(command.ClientBKDistMonitor)
+}

--- a/src/backend/booster/bk_dist/monitor/main.go
+++ b/src/backend/booster/bk_dist/monitor/main.go
@@ -10,18 +10,9 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/Tencent/bk-ci/src/booster/bk_dist/monitor/command"
-	"github.com/Tencent/bk-ci/src/booster/bk_dist/monitor/pkg"
 )
 
 func main() {
-	if !pkg.Lock() {
-		fmt.Printf("exit for other instance is already started")
-		return
-	}
-	defer pkg.Unlock()
-
 	command.Run(command.ClientBKDistMonitor)
 }

--- a/src/backend/booster/bk_dist/monitor/pkg/error.go
+++ b/src/backend/booster/bk_dist/monitor/pkg/error.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 THL A29 Limited, a Tencent company. All rights reserved
+ *
+ * This source code file is licensed under the MIT License, you may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ */
+
+package pkg
+
+import "fmt"
+
+var (
+	ErrorRuleSettingNotExisted = fmt.Errorf("not found rules file")
+	ErrFileLock                = fmt.Errorf("lock file failed")
+)

--- a/src/backend/booster/bk_dist/monitor/pkg/monitor.go
+++ b/src/backend/booster/bk_dist/monitor/pkg/monitor.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2021 THL A29 Limited, a Tencent company. All rights reserved
+ *
+ * This source code file is licensed under the MIT License, you may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ */
+
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	dcFile "github.com/Tencent/bk-ci/src/booster/bk_dist/common/file"
+	dcSyscall "github.com/Tencent/bk-ci/src/booster/bk_dist/common/syscall"
+	dcUtil "github.com/Tencent/bk-ci/src/booster/bk_dist/common/util"
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/monitor/types"
+	"github.com/Tencent/bk-ci/src/booster/common/blog"
+)
+
+const (
+	RulesFileName            = "bk_rules.json"
+	DevOPSProcessTreeKillKey = "DEVOPS_DONT_KILL_PROCESS_TREE"
+
+	DefautInterval = 20000
+)
+
+// NewMonitor get a new idle loop instance
+func NewMonitor(rf string) *Monitor {
+	return &Monitor{rulesfile: rf}
+}
+
+// Monitor to check other bk-dist process status
+type Monitor struct {
+	selfexepath string
+	rules       *types.Rules
+	rulesfile   string
+}
+
+// Run brings up idle loop
+func (m *Monitor) Run(ctx context.Context) (int, error) {
+	return m.run(ctx)
+}
+
+func (m *Monitor) run(pCtx context.Context) (int, error) {
+	defer blog.CloseLogs()
+
+	m.intEnv()
+	err := m.initRules()
+	if err != nil {
+		blog.Errorf("failed to init rules with err:%v", err)
+		return 1, nil
+	}
+
+	go m.runMonitors(pCtx)
+
+	m.runIdleLoop(pCtx)
+
+	return 0, nil
+}
+
+func (m *Monitor) runIdleLoop(ctx context.Context) {
+	for {
+		time.Sleep(3600 * time.Second)
+	}
+}
+
+func (m *Monitor) runMonitors(ctx context.Context) {
+	for _, v := range m.rules.AllRules {
+		go m.runMonitor(m.rules.DefaultIntervalMS, v, ctx)
+		time.Sleep(time.Duration(rand.Intn(3)) * time.Second)
+	}
+}
+
+func (m *Monitor) runMonitor(interval int, r types.Rule, ctx context.Context) {
+	if r.IntervalMS <= 0 {
+		r.IntervalMS = interval
+	}
+
+	if r.IntervalMS <= 0 {
+		r.IntervalMS = DefautInterval
+	}
+
+	ticker := time.NewTicker(time.Duration(r.IntervalMS) * time.Millisecond)
+	for {
+		select {
+		case <-ctx.Done():
+			blog.Debugf("monitor: controller check canceled by context")
+			return
+
+		case <-ticker.C:
+			blog.Debugf("monitor: check controller unexpected fork now")
+			m.runRule(r)
+		}
+	}
+}
+
+func (m *Monitor) runRule(r types.Rule) {
+	blog.Infof("monitor: ready run check cmd:[%s]", r.CheckCmd)
+	sandbox := dcSyscall.Sandbox{}
+	exitcode, outmsg, errmsg, err := sandbox.ExecScriptsWithMessage(r.CheckCmd)
+	if exitcode != 0 {
+		blog.Errorf("failed to execute cmd:[%s] with exit code:%d, err:%v", r.CheckCmd, exitcode, err)
+		return
+	}
+	blog.Infof("succeed to execute cmd:[%s] with exit code:%d,output:%s,errmsg:%s, err:%v",
+		r.CheckCmd, exitcode, outmsg, errmsg, err)
+
+	if len(r.RecoverCmds) > 0 {
+		if v, ok := r.RecoverCmds[string(outmsg)]; ok {
+			for _, c := range v {
+				blog.Infof("monitor: ready run recover cmd:[%s]", c)
+				exitcode, outmsg, errmsg, err := sandbox.ExecScriptsWithMessage(c)
+				if exitcode != 0 {
+					blog.Errorf("failed to execute cmd:[%s] with exit code:%d, err:%v", c, exitcode, err)
+					return
+				}
+				blog.Infof("succeed to execute cmd:[%s] with exit code:%d,output:%s,errmsg:%s, err:%v",
+					c, exitcode, outmsg, errmsg, err)
+			}
+		}
+	}
+}
+
+func (m *Monitor) initRules() error {
+	f, err := m.getRulesFile()
+	if err != nil {
+		return err
+	}
+
+	m.rules, err = resolveRules(f)
+	if err != nil {
+		return err
+	}
+
+	blog.Infof("monitor: loaded rules:%+v", *m.rules)
+
+	os.Setenv(DevOPSProcessTreeKillKey, "true")
+
+	return nil
+}
+
+func (m *Monitor) getRulesFile() (string, error) {
+	if dcFile.Stat(m.rulesfile).Exist() {
+		return m.rulesfile, nil
+	}
+
+	if m.selfexepath != "" {
+		jsonfile := filepath.Join(m.selfexepath, RulesFileName)
+		fmt.Printf("monitor: check rules file:%s\n", jsonfile)
+		if dcFile.Stat(jsonfile).Exist() {
+			return jsonfile, nil
+		}
+	}
+
+	return "", ErrorRuleSettingNotExisted
+}
+
+func (m *Monitor) intEnv() error {
+	m.selfexepath = dcUtil.GetExcPath()
+	fmt.Printf("monitor: get self exe path:%s\n", m.selfexepath)
+	if m.selfexepath != "" {
+		blog.Infof("monitor: get self exe path:%s", m.selfexepath)
+		os.Chdir(m.selfexepath)
+		dcSyscall.AddPath2Env(m.selfexepath)
+	} else {
+		blog.Infof("monitor: not found self exe path:%s", m.selfexepath)
+	}
+
+	return nil
+}

--- a/src/backend/booster/bk_dist/monitor/pkg/util.go
+++ b/src/backend/booster/bk_dist/monitor/pkg/util.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021 THL A29 Limited, a Tencent company. All rights reserved
+ *
+ * This source code file is licensed under the MIT License, you may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ */
+
+package pkg
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/flock"
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/util"
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/monitor/types"
+	"github.com/Tencent/bk-ci/src/booster/common/blog"
+	"github.com/Tencent/bk-ci/src/booster/common/codec"
+	"github.com/shirou/gopsutil/process"
+)
+
+// KillChildren kill all process children of given process
+func KillChildren(p *process.Process) {
+	children, err := p.Children()
+	if err == nil && len(children) > 0 {
+		for _, v := range children {
+			n, err := v.Name()
+			// do not kill bk-dist-controller, for it may be used by other process
+			if err == nil && strings.Contains(n, "bk-dist-controller") {
+				continue
+			}
+			KillChildren(v)
+			_ = v.Kill()
+		}
+	}
+}
+
+func resolveRules(f string) (*types.Rules, error) {
+	blog.Infof("resolve rules json file %s", f)
+
+	data, err := ioutil.ReadFile(f)
+	if err != nil {
+		blog.Errorf("failed to read rules json file %s with error %v", f, err)
+		return nil, err
+	}
+
+	var r types.Rules
+	if err = codec.DecJSON(data, &r); err != nil {
+		blog.Errorf("failed to decode json content[%s] failed: %v", string(data), err)
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+var (
+	lockfile = "bk-dist-controller.lock"
+)
+
+func getLockFile() (string, error) {
+	dir := util.GetGlobalDir()
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, lockfile), nil
+}
+
+func Lock() bool {
+	f, err := getLockFile()
+	if err != nil {
+		blog.Errorf("[controller]: failed to start with error:%v\n", err)
+		return false
+	}
+	blog.Infof("[controller]: ready lock file: %s\n", f)
+	flag, err := flock.TryLock(f)
+	if err != nil {
+		blog.Errorf("[controller]: failed to start with error:%v\n", err)
+		return false
+	}
+	if !flag {
+		blog.Infof("[controller]: program is maybe running for lock file has been locked \n")
+		return false
+	}
+
+	return true
+}
+
+func Unlock() {
+	flock.Unlock()
+}

--- a/src/backend/booster/bk_dist/monitor/pkg/util.go
+++ b/src/backend/booster/bk_dist/monitor/pkg/util.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/flock"
 	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/util"
@@ -28,11 +27,6 @@ func KillChildren(p *process.Process) {
 	children, err := p.Children()
 	if err == nil && len(children) > 0 {
 		for _, v := range children {
-			n, err := v.Name()
-			// do not kill bk-dist-controller, for it may be used by other process
-			if err == nil && strings.Contains(n, "bk-dist-controller") {
-				continue
-			}
 			KillChildren(v)
 			_ = v.Kill()
 		}
@@ -58,7 +52,7 @@ func resolveRules(f string) (*types.Rules, error) {
 }
 
 var (
-	lockfile = "bk-dist-controller.lock"
+	lockfile = "bk-dist-monitor.lock"
 )
 
 func getLockFile() (string, error) {
@@ -72,17 +66,17 @@ func getLockFile() (string, error) {
 func Lock() bool {
 	f, err := getLockFile()
 	if err != nil {
-		blog.Errorf("[controller]: failed to start with error:%v\n", err)
+		blog.Errorf("[monitor]: failed to start with error:%v\n", err)
 		return false
 	}
-	blog.Infof("[controller]: ready lock file: %s\n", f)
+	blog.Infof("[monitor]: ready lock file: %s\n", f)
 	flag, err := flock.TryLock(f)
 	if err != nil {
-		blog.Errorf("[controller]: failed to start with error:%v\n", err)
+		blog.Errorf("[monitor]: failed to start with error:%v\n", err)
 		return false
 	}
 	if !flag {
-		blog.Infof("[controller]: program is maybe running for lock file has been locked \n")
+		blog.Infof("[monitor]: program is maybe running for lock file has been locked \n")
 		return false
 	}
 

--- a/src/backend/booster/bk_dist/monitor/types/types.go
+++ b/src/backend/booster/bk_dist/monitor/types/types.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 THL A29 Limited, a Tencent company. All rights reserved
+ *
+ * This source code file is licensed under the MIT License, you may obtain a copy of the License at
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ */
+
+package types
+
+type Rule struct {
+	Name        string              `json:"name"`
+	IntervalMS  int                 `json:"interval_ms"`
+	CheckCmd    string              `json:"check_cmd"`
+	RecoverCmds map[string][]string `json:"recover_cmds"`
+}
+
+type Rules struct {
+	DefaultIntervalMS int    `json:"default_interval_ms"`
+	AllRules          []Rule `json:"all_rules"`
+}

--- a/src/backend/booster/bk_dist/shadertool/common/types.go
+++ b/src/backend/booster/bk_dist/shadertool/common/types.go
@@ -81,6 +81,7 @@ type Actionresult struct {
 	Succeed   bool
 	Outputmsg string
 	Errormsg  string
+	Exitcode  int
 }
 
 func uniqueAndCheck(strlist []string, allindex map[string]bool) []string {

--- a/src/backend/booster/bk_dist/ubttool/command/process.go
+++ b/src/backend/booster/bk_dist/ubttool/command/process.go
@@ -75,6 +75,7 @@ func sysSignalHandler(cancel context.CancelFunc, handle *pkg.UBTTool) {
 func newCustomProcess(c *commandCli.Context) *pkg.UBTTool {
 	return pkg.NewUBTTool(&common.Flags{
 		ActionChainFile: c.String(FlagActionJSONFile),
+		ToolChainFile:   c.String(FlagToolChainJSONFile),
 		MostDepentFirst: c.Bool(FlagMostDependFirst),
 	}, sdk.ControllerConfig{
 		NoLocal: false,

--- a/src/backend/booster/bk_dist/ubttool/common/types.go
+++ b/src/backend/booster/bk_dist/ubttool/common/types.go
@@ -9,9 +9,16 @@
 
 package common
 
+import (
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/env"
+	dcUtil "github.com/Tencent/bk-ci/src/booster/bk_dist/common/util"
+	"github.com/Tencent/bk-ci/src/booster/common/blog"
+)
+
 // Flags to desc flag of this tool
 type Flags struct {
 	ActionChainFile string
+	ToolChainFile   string
 	MostDepentFirst bool
 }
 
@@ -97,4 +104,28 @@ func (a *UE4Action) GenFolloweIndex() error {
 	}
 
 	return nil
+}
+
+// SetLogLevel to set log level
+func SetLogLevel(level string) {
+	if level == "" {
+		level = env.GetEnv(env.KeyUserDefinedLogLevel)
+	}
+
+	switch level {
+	case dcUtil.PrintDebug.String():
+		blog.SetV(3)
+		blog.SetStderrLevel(blog.StderrLevelInfo)
+	case dcUtil.PrintInfo.String():
+		blog.SetStderrLevel(blog.StderrLevelInfo)
+	case dcUtil.PrintWarn.String():
+		blog.SetStderrLevel(blog.StderrLevelWarning)
+	case dcUtil.PrintError.String():
+		blog.SetStderrLevel(blog.StderrLevelError)
+	case dcUtil.PrintNothing.String():
+		blog.SetStderrLevel(blog.StderrLevelNothing)
+	default:
+		// default to be error printer.
+		blog.SetStderrLevel(blog.StderrLevelInfo)
+	}
 }

--- a/src/backend/booster/bk_dist/ubttool/pkg/error.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/error.go
@@ -12,7 +12,28 @@ package pkg
 import "fmt"
 
 var (
-	ErrorNoActionsToRun = fmt.Errorf("not found any action to execute")
-	ErrorOverMaxTime    = fmt.Errorf("execute over max wait seconds")
-	ErrorInvalidWorkID  = fmt.Errorf("not found valid work id")
+	ErrorNoActionsToRun           = fmt.Errorf("not found any action to execute")
+	ErrorOverMaxTime              = fmt.Errorf("execute over max wait seconds")
+	ErrorInvalidWorkID            = fmt.Errorf("not found valid work id")
+	ErrorProjectSettingNotExisted = fmt.Errorf("not found project setting file")
+	ErrorUnknown                  = fmt.Errorf("unknown error")
 )
+
+var errorCodeMap map[error]int
+
+func init() {
+	errorCodeMap = map[error]int{
+		ErrorProjectSettingNotExisted: 6,
+		ErrorUnknown:                  99,
+	}
+}
+
+// GetErrorCode return error code by error
+func GetErrorCode(err error) int {
+	if v, ok := errorCodeMap[err]; ok {
+		return v
+	}
+
+	// default error code
+	return 99
+}

--- a/src/backend/booster/bk_dist/ubttool/pkg/executor.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/executor.go
@@ -55,8 +55,14 @@ func (d *Executor) Valid() bool {
 	return d.work.ID() != ""
 }
 
+// Update update with env
+func (d *Executor) Update() {
+	d.work = v1.NewSDK(dcSDK.GetControllerConfigFromEnv()).GetWork(env.GetEnv(env.KeyExecutorControllerWorkID))
+	d.taskID = env.GetEnv(env.KeyExecutorTaskID)
+}
+
 // Run main function entry
-func (d *Executor) Run(fullargs []string, workdir string) (int, error) {
+func (d *Executor) Run(fullargs []string, workdir string) (int, string, error) {
 	blog.Infof("ubtexecutor: command [%s] begins", strings.Join(fullargs, " "))
 	for i, v := range fullargs {
 		blog.Infof("ubtexecutor: arg[%d] : [%s]", i, v)
@@ -67,19 +73,19 @@ func (d *Executor) Run(fullargs []string, workdir string) (int, error) {
 	return d.runWork(fullargs, workdir)
 }
 
-func (d *Executor) runWork(fullargs []string, workdir string) (int, error) {
+func (d *Executor) runWork(fullargs []string, workdir string) (int, string, error) {
 	// d.initStats()
 
 	// ignore argv[0], it's itself
-	r, err := d.work.Job(d.getStats(fullargs)).ExecuteLocalTask(fullargs, workdir)
-	if err != nil {
+	retcode, retmsg, r, err := d.work.Job(d.getStats(fullargs)).ExecuteLocalTask(fullargs, workdir)
+	if err != nil || retcode != 0 {
 		if r != nil {
-			blog.Errorf("ubtexecutor: execute failed, error: %v, exit code: -1, outmsg:%s,errmsg:%s,cmd:%v",
-				err, string(r.Stdout), string(r.Stderr), fullargs)
+			blog.Errorf("ubtexecutor: execute failed, error: %v, ret code: %d,retmsg:%s,outmsg:%s,errmsg:%s,cmd:%v",
+				err, retcode, retmsg, string(r.Stdout), string(r.Stderr), fullargs)
 		} else {
-			blog.Errorf("ubtexecutor: execute failed, error: %v,cmd:%v", err, fullargs)
+			blog.Errorf("ubtexecutor: execute failed, ret code:%d retmsg:%s error: %v,cmd:%v", retcode, retmsg, err, fullargs)
 		}
-		return -1, err
+		return retcode, retmsg, err
 	}
 
 	charcode := 0
@@ -152,10 +158,10 @@ func (d *Executor) runWork(fullargs []string, workdir string) (int, error) {
 	if r.ExitCode != 0 {
 		blog.Errorf("ubtexecutor: execute failed, error: %v, exit code: %d, outmsg:%s,errmsg:%s,cmd:%v",
 			err, r.ExitCode, string(r.Stdout), string(r.Stderr), fullargs)
-		return r.ExitCode, err
+		return r.ExitCode, retmsg, err
 	}
 
-	return 0, nil
+	return 0, retmsg, nil
 }
 
 func (d *Executor) getStats(fullargs []string) *dcSDK.ControllerJobStats {

--- a/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
@@ -12,18 +12,29 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/booster/pkg"
 	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/env"
+	dcFile "github.com/Tencent/bk-ci/src/booster/bk_dist/common/file"
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/common/sdk"
 	dcSDK "github.com/Tencent/bk-ci/src/booster/bk_dist/common/sdk"
+	dcType "github.com/Tencent/bk-ci/src/booster/bk_dist/common/types"
+	dcUtil "github.com/Tencent/bk-ci/src/booster/bk_dist/common/util"
+	"github.com/Tencent/bk-ci/src/booster/bk_dist/controller/pkg/api"
 	v1 "github.com/Tencent/bk-ci/src/booster/bk_dist/controller/pkg/api/v1"
 	"github.com/Tencent/bk-ci/src/booster/bk_dist/ubttool/common"
 	"github.com/Tencent/bk-ci/src/booster/common/blog"
+	"github.com/Tencent/bk-ci/src/booster/common/codec"
+
+	shaderToolComm "github.com/Tencent/bk-ci/src/booster/bk_dist/shadertool/common"
 
 	"github.com/google/shlex"
 )
@@ -33,11 +44,13 @@ const (
 	MaxWaitSecs = 10800
 	TickSecs    = 30
 	DefaultJobs = 240 // ok for most machines
+
+	DevOPSProcessTreeKillKey = "DEVOPS_DONT_KILL_PROCESS_TREE"
 )
 
 // NewUBTTool get a new UBTTool
 func NewUBTTool(flagsparam *common.Flags, config dcSDK.ControllerConfig) *UBTTool {
-	blog.Infof("UBTTool: new helptool with config:%+v,flags:%+v", config, *flagsparam)
+	blog.Infof("UBTTool: new ubt tool with config:%+v,flags:%+v", config, *flagsparam)
 
 	return &UBTTool{
 		flags:          flagsparam,
@@ -75,7 +88,12 @@ type UBTTool struct {
 
 	actionchan chan common.Actionresult
 
+	booster  *pkg.Booster
 	executor *Executor
+
+	// settings
+	projectSettingFile string
+	settings           *shaderToolComm.ApplyParameters
 }
 
 // Run run the tool
@@ -84,8 +102,14 @@ func (h *UBTTool) Run(ctx context.Context) (int, error) {
 }
 
 func (h *UBTTool) run(pCtx context.Context) (int, error) {
+	// update path env
+	err := h.initsettings()
+	if err != nil {
+		return GetErrorCode(err), err
+	}
+
 	blog.Infof("UBTTool: try to find controller or launch it")
-	_, err := h.controller.EnsureServer()
+	_, err = h.controller.EnsureServer()
 	if err != nil {
 		blog.Errorf("UBTTool: ensure controller failed: %v", err)
 		return 1, err
@@ -298,11 +322,24 @@ func (h *UBTTool) executeOneAction(action common.Action, actionchan chan common.
 
 	//exitcode, err := h.executor.Run(fullargs, action.Workdir)
 	// try again if failed after sleep some time
-	var exitcode int
+	var retcode int
+	retmsg := ""
 	waitsecs := 5
 	var err error
 	for try := 0; try < 6; try++ {
-		exitcode, err = h.executor.Run(fullargs, action.Workdir)
+		retcode, retmsg, err = h.executor.Run(fullargs, action.Workdir)
+		if retcode != int(api.ServerErrOK) {
+			blog.Warnf("UBTTool: failed to execute action with ret code:%d error [%+v] for %d times, actions:%+v", retcode, err, try+1, action)
+
+			if retcode == int(api.ServerErrWorkNotFound) {
+				h.dealWorkNotFound(retcode, retmsg)
+			}
+
+			time.Sleep(time.Duration(waitsecs) * time.Second)
+			waitsecs = waitsecs * 2
+			continue
+		}
+
 		if err != nil {
 			blog.Warnf("UBTTool: failed to execute action with error [%+v] for %d times, actions:%+v", err, try+1, action)
 			time.Sleep(time.Duration(waitsecs) * time.Second)
@@ -318,7 +355,7 @@ func (h *UBTTool) executeOneAction(action common.Action, actionchan chan common.
 		Succeed:   err == nil,
 		Outputmsg: "",
 		Errormsg:  "",
-		Exitcode:  exitcode,
+		Exitcode:  retcode,
 	}
 
 	actionchan <- r
@@ -421,4 +458,177 @@ func (h *UBTTool) dump() {
 		blog.Infof("UBTTool: action:%+v", v)
 	}
 	blog.Infof("UBTTool: -------------------dump end-----------------------")
+}
+
+//---------------------------------to support set tool chain----------------------------------------------------------
+func (h *UBTTool) initsettings() error {
+	var err error
+	h.projectSettingFile, err = h.getProjectSettingFile()
+	if err != nil {
+		return err
+	}
+
+	h.settings, err = resolveApplyJSON(h.projectSettingFile)
+	if err != nil {
+		return err
+	}
+
+	blog.Infof("UBTTool: loaded setting:%+v", *h.settings)
+
+	for k, v := range h.settings.Env {
+		blog.Infof("UBTTool: set env %s=%s", k, v)
+		os.Setenv(k, v)
+
+		if k == "BK_DIST_LOG_LEVEL" {
+			common.SetLogLevel(v)
+		}
+	}
+	os.Setenv(DevOPSProcessTreeKillKey, "true")
+
+	return nil
+}
+
+func (h *UBTTool) getProjectSettingFile() (string, error) {
+	exepath := dcUtil.GetExcPath()
+	if exepath != "" {
+		jsonfile := filepath.Join(exepath, "bk_project_setting.json")
+		if dcFile.Stat(jsonfile).Exist() {
+			return jsonfile, nil
+		}
+	}
+
+	return "", ErrorProjectSettingNotExisted
+}
+
+func resolveApplyJSON(filename string) (*shaderToolComm.ApplyParameters, error) {
+	blog.Infof("resolve apply json file %s", filename)
+
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		blog.Errorf("failed to read apply json file %s with error %v", filename, err)
+		return nil, err
+	}
+
+	var t shaderToolComm.ApplyParameters
+	if err = codec.DecJSON(data, &t); err != nil {
+		blog.Errorf("failed to decode json content[%s] failed: %v", string(data), err)
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+func (h *UBTTool) newBooster() (*pkg.Booster, error) {
+	blog.Infof("UBTTool: new booster in...")
+
+	// get current running dir.
+	// if failed, it doesn't matter, just give a warning.
+	runDir, err := os.Getwd()
+	if err != nil {
+		blog.Warnf("booster-command: get working dir failed: %v", err)
+	}
+
+	// get current user, use the login username.
+	// if failed, it doesn't matter, just give a warning.
+	usr, err := user.Current()
+	if err != nil {
+		blog.Warnf("booster-command: get current user failed: %v", err)
+	}
+
+	// decide which server to connect to.
+	ServerHost := h.settings.ServerHost
+	projectID := h.settings.ProjectID
+	buildID := h.settings.BuildID
+
+	// generate a new booster.
+	cmdConfig := dcType.BoosterConfig{
+		Type:      dcType.BoosterType(h.settings.Scene),
+		ProjectID: projectID,
+		BuildID:   buildID,
+		BatchMode: h.settings.BatchMode,
+		Args:      "",
+		Cmd:       strings.Join(os.Args, " "),
+		Works: dcType.BoosterWorks{
+			Stdout:            os.Stdout,
+			Stderr:            os.Stderr,
+			RunDir:            runDir,
+			User:              usr.Username,
+			WorkerList:        h.settings.WorkerList,
+			LimitPerWorker:    h.settings.LimitPerWorker,
+			MaxLocalTotalJobs: defaultCPULimit(h.settings.MaxLocalTotalJobs),
+			MaxLocalPreJobs:   h.settings.MaxLocalPreJobs,
+			MaxLocalExeJobs:   h.settings.MaxLocalExeJobs,
+			MaxLocalPostJobs:  h.settings.MaxLocalPostJobs,
+		},
+
+		Transport: dcType.BoosterTransport{
+			ServerHost:             ServerHost,
+			Timeout:                5 * time.Second,
+			HeartBeatTick:          5 * time.Second,
+			InspectTaskTick:        1 * time.Second,
+			TaskPreparingTimeout:   60 * time.Second,
+			PrintTaskInfoEveryTime: 5,
+			CommitSuicideCheckTick: 5 * time.Second,
+		},
+
+		Controller: sdk.ControllerConfig{
+			NoLocal: false,
+			Scheme:  shaderToolComm.ControllerScheme,
+			IP:      shaderToolComm.ControllerIP,
+			Port:    shaderToolComm.ControllerPort,
+			Timeout: 5 * time.Second,
+		},
+	}
+
+	return pkg.NewBooster(cmdConfig)
+}
+
+func (h *UBTTool) setToolChain() error {
+	blog.Infof("UBTTool: set toolchain in...")
+
+	var err error
+	if h.booster == nil {
+		h.booster, err = h.newBooster()
+		if err != nil || h.booster == nil {
+			blog.Errorf("UBTTool: failed to new booster: %v", err)
+			return err
+		}
+	}
+
+	err = h.booster.SetToolChain(h.flags.ToolChainFile)
+	if err != nil {
+		blog.Errorf("UBTTool: failed to set tool chain, error: %v", err)
+	}
+
+	return err
+}
+
+func (h *UBTTool) dealWorkNotFound(retcode int, retmsg string) error {
+	blog.Infof("UBTTool: deal for work not found with code:%d, msg:%s", retcode, retmsg)
+
+	if retmsg == "" {
+		return nil
+	}
+
+	msgs := strings.Split(retmsg, "|")
+	if len(msgs) < 2 {
+		return nil
+	}
+
+	var workerid v1.WorkerChanged
+	if err := codec.DecJSON([]byte(msgs[1]), &workerid); err != nil {
+		blog.Errorf("UBTTool: decode param %s failed: %v", msgs[1], err)
+		return err
+	}
+
+	if workerid.NewWorkID != "" {
+		// update local workid with new workid
+		env.SetEnv(env.KeyExecutorControllerWorkID, workerid.NewWorkID)
+		h.executor.Update()
+
+		// set tool chain with new workid
+		h.setToolChain()
+	}
+
+	return nil
 }

--- a/src/backend/booster/bk_dist/ubttool/pkg/util.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/util.go
@@ -11,6 +11,7 @@ package pkg
 
 import (
 	"io/ioutil"
+	"runtime"
 	"strings"
 	"sync/atomic"
 
@@ -18,6 +19,13 @@ import (
 	"github.com/Tencent/bk-ci/src/booster/common/blog"
 	"github.com/Tencent/bk-ci/src/booster/common/codec"
 )
+
+func defaultCPULimit(custom int) int {
+	if custom > 0 {
+		return custom
+	}
+	return runtime.NumCPU() - 2
+}
 
 func resolveActionJSON(filename string) (*common.UE4Action, error) {
 	blog.Debugf("resolve action json file %s", filename)

--- a/src/backend/booster/win_compile.bat
+++ b/src/backend/booster/win_compile.bat
@@ -47,6 +47,8 @@ go build -ldflags "%LDFLAG% %BuildBooster_LDFLAG%" -o %bindir%\bk-booster.exe %c
 
 go build -ldflags "%LDFLAG% %BuildBooster_LDFLAG%" -o %bindir%\bk-idle-loop.exe %curpath%\bk_dist\idleloop\main.go
 
+go build -ldflags "%LDFLAG% %BuildBooster_LDFLAG%" -o %bindir%\bk-dist-monitor.exe %curpath%\bk_dist\monitor\main.go
+
 go build -ldflags "%LDFLAG% %BuildBooster_LDFLAG%" -o %bindir%\bk-help-tool.exe %curpath%\bk_dist\helptool\main.go
 
 go build -ldflags "%LDFLAG% %BuildBooster_LDFLAG%" -o %bindir%\bk-ubt-tool.exe %curpath%\bk_dist\ubttool\main.go


### PR DESCRIPTION
1. bk-shader-tool 和 bk-ubt-tool 支持重试，方便 controller重启后恢复
2. controller 支持将新的 worker id 发给 shader和ubt tool，方便shader和ubt tool 用新的work id 执行任务
3. shader 和 ubt tool 支持发送工具链
4. 支持统计数据的更新
5. 支持资源的自动申请和释放
6. 重启方式，是用默认的 bk_apply_ubt.sh 拉起controller，尽量保证参数一致
7. 重启后的 controller 会用常驻的模式（bk-booster会维持worker的心跳，因为重新拉起，没有明确的截止条件）
8. 新增 bk-dist-monitor 进程，方便定制监控