### PR TITLE
修正bk-dist-controller两个bug

### DIFF
--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/mgr.go
@@ -135,8 +135,10 @@ func (m *Mgr) ExecuteTask(
 	}
 
 	// 没有申请到资源(或资源已释放) || 申请到资源但都失效了
-	if !m.work.Resource().HasAvailableWorkers() ||
-		m.work.Remote().TotalSlots() <= 0 {
+	// if !m.work.Resource().HasAvailableWorkers() ||
+	// 	m.work.Remote().TotalSlots() <= 0 {
+	// !! 去掉申请到资源但失效的情况，因为该情况很可能是网络原因，再加资源也没有意义
+	if !m.work.Resource().HasAvailableWorkers() {
 		// check whether this task need remote worker,
 		// apply resource when need, if not in appling, apply then
 		if e.needRemoteResource() {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/resource/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/resource/mgr.go
@@ -154,7 +154,10 @@ func (m *Mgr) GetNewlyTaskID() string {
 // SetSpecificHosts set the specific worker list instead of applying
 func (m *Mgr) SetSpecificHosts(hostList []string) {
 	m.reslock.Lock()
-	defer m.reslock.Unlock()
+	defer func() {
+		m.reslock.Unlock()
+		m.onResChanged()
+	}()
 	m.resources = append(m.resources, &Res{
 		taskid: "",
 		status: ResourceSpecified,
@@ -169,7 +172,7 @@ func (m *Mgr) SetSpecificHosts(hostList []string) {
 		info.ResourceApplied()
 	}
 
-	m.onResChanged()
+	// m.onResChanged()
 }
 
 // GetHosts return the worker list


### PR DESCRIPTION
1. 指定host的死锁
2. remote worker全部失效后，会导致资源一直申请而不释放