### PR TITLE
bug: 质量红线生效流水线信息在红线列表页面和详情页面数据不一致 #8073

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/template/ServiceTemplateInstanceResourceImpl.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/api/template/ServiceTemplateInstanceResourceImpl.kt
@@ -64,7 +64,7 @@ class ServiceTemplateInstanceResourceImpl @Autowired constructor(
     }
 
     override fun countTemplateInstance(projectId: String, templateIds: Collection<String>): Result<Int> {
-        return Result(templateFacadeService.serviceCountTemplateInstances(projectId, templateIds))
+        return Result(data = templateFacadeService.serviceCountTemplateInstances(projectId, templateIds))
     }
 
     override fun countTemplateInstanceDetail(


### PR DESCRIPTION
质量红线生效流水线信息在红线列表页面和详情页面数据不一致