### PR TITLE
bug：带失败时自动跳过插件的流水线构建时因为构建机网络原因结束后的状态不正确 #8140

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/enums/BuildStatus.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/enums/BuildStatus.kt
@@ -75,6 +75,8 @@ enum class BuildStatus(val statusName: String, val visible: Boolean) {
 
     fun isSkip(): Boolean = this == SKIP
 
+    fun isTerminate(): Boolean = this == TERMINATE
+
     fun isRunning(): Boolean =
         this == RUNNING ||
             this == LOOP_WAITING ||

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -202,7 +202,8 @@ class StartActionTaskContainerCmd(
                     containerContext.buildStatus = BuildStatusSwitcher.jobStatusMaker.forceFinish(t.status, fastKill)
                 } else {
                     continueWhenFailure = true
-                    if (needTerminate || t.status.isCancel()) { // #4301 强制终止的标志为失败，不管是不是设置了失败继续[P0]
+                    if (needTerminate || t.status.isCancel() || t.status.isTerminate()) {
+                        // #4301 强制终止的标志为失败，不管是不是设置了失败继续[P0]
                         containerContext.buildStatus = BuildStatusSwitcher.jobStatusMaker.forceFinish(t.status)
                     }
                 }


### PR DESCRIPTION
bug：带失败时自动跳过插件的流水线构建时因为构建机网络原因结束后的状态不正确 #8140
#8140