### PR TITLE
bug:人工审核插件重试后通知内容里引用的变量值还是上一次执行的值 #12723

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -1654,11 +1654,7 @@ class PipelineRuntimeService @Autowired constructor(
                     taskBuildRecordService.updateTaskRecord(
                         projectId = projectId, pipelineId = pipelineId, buildId = buildId,
                         taskId = taskId, executeCount = executeCount ?: 1, buildStatus = null,
-                        taskVar = mapOf(
-                            ManualReviewUserTaskElement::desc.name to (params.desc ?: ""),
-                            ManualReviewUserTaskElement::suggest.name to (params.suggest ?: ""),
-                            ManualReviewUserTaskElement::params.name to params.params
-                        ),
+                        taskVar = mapOf(),
                         operation = "manualDealReview#$taskId",
                         timestamps = mapOf(
                             BuildTimestampType.TASK_REVIEW_PAUSE_WAITING to


### PR DESCRIPTION
bug:人工审核插件重试后通知内容里引用的变量值还是上一次执行的值 #12723