### PR TITLE
bug:流水线在job超时报错时，当时报错的插件不会写入到BK_CI_BUILD_FAIL_TASKS这个变量里

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildTaskService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineBuildTaskService.kt
@@ -87,9 +87,11 @@ class PipelineBuildTaskService @Autowired constructor(
         if (sendEventFlag) {
             // 失败的任务并且不是需要前置终止的情况才允许自动重试
             val errorCode = buildTask.errorCode ?: 0
-            if (buildStatus.isFailure() && !actionType.isTerminate() && !FastKillUtils.isTerminateCode(errorCode)) {
+            if (buildStatus.isFailure() && !FastKillUtils.isTerminateCode(errorCode)) {
                 // 如果配置了失败重试，且重试次数上线未达上限，则将状态设置为重试，让其进入
-                if (pipelineTaskService.isRetryWhenFail(buildTask.projectId, taskId, buildId, buildTask.errorMsg)) {
+                if (!actionType.isTerminate() &&
+                    pipelineTaskService.isRetryWhenFail(buildTask.projectId, taskId, buildId, buildTask.errorMsg)
+                ) {
                     logger.info("ENGINE|$buildId|$source|ATOM_FIN|$stageId|j($containerId)|t($taskId)|RetryFail")
                     // 将当前重试 task id 做记录
                     pipelineTaskService.taskRetryRecordSet(


### PR DESCRIPTION
Job 超时触发的是 ActionType.TERMINATE 事件
在 finishTask 方法中，由于 actionType.isTerminate() 为 true，导致 !actionType.isTerminate() 条件不满足
代码进入 else 分支，执行的是 removeFailTaskVar（清理）而非 createFailTaskVar（记录）