### PR TITLE
bug: 应用设置可见范围只选择根组织时，在应用商店里生效范围有误 #12768

### DIFF
--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/common/dao/MarketStoreQueryDao.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/common/dao/MarketStoreQueryDao.kt
@@ -179,7 +179,7 @@ class MarketStoreQueryDao {
             val tStoreBaseFeature = TStoreBaseFeature.T_STORE_BASE_FEATURE
             val deptCondition = tStoreDeptRel.STORE_CODE.eq(tStoreBase.STORE_CODE)
                 .and(tStoreDeptRel.STORE_TYPE.eq(tStoreBase.STORE_TYPE))
-                .and(tStoreDeptRel.DEPT_ID.`in`(userDeptList))
+                .and(tStoreDeptRel.DEPT_ID.eq(0).or(tStoreDeptRel.DEPT_ID.`in`(userDeptList)))
             val existsCondition = DSL.exists(
                 dslContext.selectOne()
                     .from(tStoreDeptRel)


### PR DESCRIPTION
bug: 应用设置可见范围只选择根组织时，在应用商店里生效范围有误 #12768