### PR TITLE
pref：增强蓝盾智能助手分析用户权限能力 #13117

### DIFF
--- a/src/backend/ci/core/ai/biz-ai/src/main/kotlin/com/tencent/devops/ai/agent/auth/AuthPermissionInsightTools.kt
+++ b/src/backend/ci/core/ai/biz-ai/src/main/kotlin/com/tencent/devops/ai/agent/auth/AuthPermissionInsightTools.kt
@@ -27,7 +27,10 @@
 
 package com.tencent.devops.ai.agent.auth
 
+import com.tencent.devops.auth.pojo.enum.JoinedType
 import com.tencent.devops.auth.pojo.request.ai.GroupRecommendReq
+import com.tencent.devops.auth.pojo.vo.PermissionDiagnoseVO
+import com.tencent.devops.auth.pojo.vo.UserPermissionAnalysisVO
 import com.tencent.devops.common.client.Client
 import io.agentscope.core.tool.Tool
 import io.agentscope.core.tool.ToolParam
@@ -48,7 +51,7 @@ class AuthPermissionInsightTools(
     @Tool(
         name = "分析用户权限",
         description = "分析用户在项目中的权限概况，生成权限分析报告。" +
-                "返回：角色、各资源类型用户组数、过期统计、告警。" +
+                "返回：角色、各资源类型用户组数、过期统计、继承来源摘要、告警。" +
                 "管理员可查任意成员，普通用户只能查自己。"
     )
     fun analyzeUserPermissions(
@@ -64,7 +67,7 @@ class AuthPermissionInsightTools(
                 memberId = memberId
             )
             val vo = result.data ?: return@safeQuery "分析失败: ${result.message}"
-            toJson(vo)
+            renderUserPermissionAnalysis(memberId, vo)
         }
     }
 
@@ -131,8 +134,8 @@ class AuthPermissionInsightTools(
 
     @Tool(
         name = "权限诊断",
-        description = "诊断用户为什么没有某个权限。分析原因并给出解决建议。\n" +
-                "适用场景：用户反馈无权限时，快速定位问题原因。"
+        description = "诊断用户为什么有或没有某个权限。分析原因并给出解决建议。\n" +
+                "适用场景：解释权限来源，或用户反馈无权限时快速定位问题原因。"
     )
     fun diagnosePermission(
         @ToolParam(name = "projectId", description = "项目ID")
@@ -156,32 +159,7 @@ class AuthPermissionInsightTools(
                 action = action
             )
             val vo = result.data ?: return@safeQuery "诊断失败: ${result.message}"
-
-            val sb = StringBuilder()
-            sb.appendLine("=== 权限诊断结果 ===")
-            sb.appendLine("用户: $memberId")
-            sb.appendLine("资源: ${vo.resourceName} (${vo.resourceType})")
-            sb.appendLine("操作: ${vo.actionName} (${vo.action})")
-            sb.appendLine("当前状态: ${if (vo.hasPermission) "✓ 有权限" else "✗ 无权限"}")
-
-            if (!vo.hasPermission) {
-                if (!vo.missingReason.isNullOrBlank()) {
-                    sb.appendLine("\n缺失原因: ${vo.missingReason}")
-                }
-                if (vo.applicableGroups.isNotEmpty()) {
-                    sb.appendLine("\n可申请的用户组:")
-                    vo.applicableGroups.take(5).forEach { group ->
-                        sb.appendLine("- ${group.groupName} (ID: ${group.groupId})")
-                    }
-                }
-                if (vo.groupManagers.isNotEmpty()) {
-                    sb.appendLine("\n可联系管理员: ${vo.groupManagers.joinToString(", ")}")
-                }
-                if (!vo.suggestion.isNullOrBlank()) {
-                    sb.appendLine("\n建议: ${vo.suggestion}")
-                }
-            }
-            sb.toString()
+            renderPermissionDiagnosis(memberId, vo)
         }
     }
 
@@ -295,5 +273,111 @@ class AuthPermissionInsightTools(
 
             sb.toString()
         }
+    }
+}
+
+internal fun renderUserPermissionAnalysis(
+    memberId: String,
+    analysis: UserPermissionAnalysisVO
+): String {
+    val sb = StringBuilder()
+    sb.appendLine("=== 用户权限分析 ===")
+    sb.appendLine("用户: $memberId")
+    sb.appendLine("角色: ${analysis.roleDisplayName}")
+    sb.appendLine("用户组总数: ${analysis.totalGroupCount}")
+    sb.appendLine("过期用户组: ${analysis.expiredGroupCount}")
+    sb.appendLine("授权总数: ${analysis.totalAuthorizationCount}")
+    sb.appendLine("项目全量权限: ${if (analysis.hasAllPermissions) "是" else "否"}")
+
+    if (analysis.resourceSummary.isNotEmpty()) {
+        sb.appendLine("\n资源类型概况:")
+        analysis.resourceSummary.forEach { summary ->
+            sb.appendLine("- ${summary.resourceTypeName}: ${summary.groupCount} 个用户组")
+        }
+    }
+
+    if (analysis.inheritedGroups.isNotEmpty()) {
+        sb.appendLine("\n代表性的继承来源:")
+        analysis.inheritedGroups.forEach { group ->
+            val source = formatJoinSource(
+                joinedType = group.joinedType,
+                joinedMemberName = group.joinedMemberName,
+                joinedMemberId = group.joinedMemberId,
+                groupName = group.groupName
+            )
+            sb.appendLine("- $source (${group.managementLevel}: ${group.resourceName})")
+        }
+    }
+
+    if (analysis.warnings.isNotEmpty()) {
+        sb.appendLine("\n告警:")
+        analysis.warnings.forEach { warning ->
+            sb.appendLine("- $warning")
+        }
+    }
+    return sb.toString()
+}
+
+internal fun renderPermissionDiagnosis(
+    memberId: String,
+    diagnose: PermissionDiagnoseVO
+): String {
+    val sb = StringBuilder()
+    sb.appendLine("=== 权限诊断结果 ===")
+    sb.appendLine("用户: $memberId")
+    sb.appendLine("资源: ${diagnose.resourceName} (${diagnose.resourceType})")
+    sb.appendLine("操作: ${diagnose.actionName} (${diagnose.action})")
+    sb.appendLine("当前状态: ${if (diagnose.hasPermission) "✓ 有权限" else "✗ 无权限"}")
+
+    if (diagnose.hasPermission) {
+        if (diagnose.permissionSourceGroups.isNotEmpty()) {
+            sb.appendLine("\n权限来源:")
+            diagnose.permissionSourceGroups.forEach { group ->
+                val joinSource = formatJoinSource(
+                    joinedType = group.joinedType,
+                    joinedMemberName = group.joinedMemberName,
+                    joinedMemberId = group.joinedMemberId,
+                    groupName = group.groupName
+                )
+                val permissions = group.permissions.joinToString("、")
+                sb.appendLine("- $joinSource")
+                sb.appendLine("  范围: ${group.managementLevel} / ${group.managementScope}")
+                if (permissions.isNotBlank()) {
+                    sb.appendLine("  权限: $permissions")
+                }
+            }
+        }
+    } else {
+        if (!diagnose.missingReason.isNullOrBlank()) {
+            sb.appendLine("\n缺失原因: ${diagnose.missingReason}")
+        }
+        if (diagnose.applicableGroups.isNotEmpty()) {
+            sb.appendLine("\n可申请的用户组:")
+            diagnose.applicableGroups.take(5).forEach { group ->
+                sb.appendLine("- ${group.groupName} (ID: ${group.groupId})")
+            }
+        }
+        if (diagnose.groupManagers.isNotEmpty()) {
+            sb.appendLine("\n可联系管理员: ${diagnose.groupManagers.joinToString(", ")}")
+        }
+    }
+
+    if (!diagnose.suggestion.isNullOrBlank()) {
+        sb.appendLine("\n建议: ${diagnose.suggestion}")
+    }
+    return sb.toString()
+}
+
+private fun formatJoinSource(
+    joinedType: JoinedType,
+    joinedMemberName: String?,
+    joinedMemberId: String?,
+    groupName: String
+): String {
+    val sourceName = joinedMemberName ?: joinedMemberId
+    return when (joinedType) {
+        JoinedType.DEPARTMENT -> "通过组织 $sourceName 继承到用户组 $groupName"
+        JoinedType.TEMPLATE -> "通过用户组模板 $sourceName 继承到用户组 $groupName"
+        JoinedType.DIRECT -> "直接加入用户组 $groupName"
     }
 }

--- a/src/backend/ci/core/ai/biz-ai/src/main/kotlin/com/tencent/devops/ai/agent/auth/AuthPermissionInsightTools.kt
+++ b/src/backend/ci/core/ai/biz-ai/src/main/kotlin/com/tencent/devops/ai/agent/auth/AuthPermissionInsightTools.kt
@@ -318,6 +318,7 @@ internal fun renderUserPermissionAnalysis(
     return sb.toString()
 }
 
+@Suppress("NestedBlockDepth")
 internal fun renderPermissionDiagnosis(
     memberId: String,
     diagnose: PermissionDiagnoseVO

--- a/src/backend/ci/core/ai/biz-ai/src/main/kotlin/com/tencent/devops/ai/agent/auth/AuthSubAgentOperationGuide.kt
+++ b/src/backend/ci/core/ai/biz-ai/src/main/kotlin/com/tencent/devops/ai/agent/auth/AuthSubAgentOperationGuide.kt
@@ -151,6 +151,11 @@ internal fun authSubAgentOperationGuideMarkdown(): String = """
 - 查询资源权限优先用 `getResourcePermissionsMatrix`
 - 查询成员有哪些权限、过期权限、执行权限时，优先用 `getAllMemberGroups`
 - 用户反馈“为什么没有权限”时，用 `diagnosePermission`
+- 用户追问“为什么他有这个权限”时，也优先用 `diagnosePermission`，明确说明
+  “加入来源 -> 用户组 -> 权限范围 -> 动作”的继承链
+- “范围型权限”优先查用户组来源，“具体资源权限”再用 `diagnosePermission`
+- 如果发现是通过部门/组织继承的权限，必须直接说明具体部门/组织和命中的用户组，
+  不要只回答“用户已拥有该权限”
 
 ### 授权、申请与续期
 

--- a/src/backend/ci/core/auth/api-auth/src/main/kotlin/com/tencent/devops/auth/pojo/vo/GroupDetailsInfoVo.kt
+++ b/src/backend/ci/core/auth/api-auth/src/main/kotlin/com/tencent/devops/auth/pojo/vo/GroupDetailsInfoVo.kt
@@ -29,6 +29,10 @@ data class GroupDetailsInfoVo(
     val removeMemberButtonControl: RemoveMemberButtonControl,
     @get:Schema(title = "加入方式")
     val joinedType: JoinedType,
+    @get:Schema(title = "加入来源成员ID，直接加入时为用户ID，组织加入时为组织ID")
+    val joinedMemberId: String? = null,
+    @get:Schema(title = "加入来源成员名称，组织加入时为组织名称")
+    val joinedMemberName: String? = null,
     @get:Schema(title = "操作人")
     val operator: String,
     @get:Schema(title = "是否正在交接")

--- a/src/backend/ci/core/auth/api-auth/src/main/kotlin/com/tencent/devops/auth/pojo/vo/PermissionDiagnoseVO.kt
+++ b/src/backend/ci/core/auth/api-auth/src/main/kotlin/com/tencent/devops/auth/pojo/vo/PermissionDiagnoseVO.kt
@@ -1,5 +1,6 @@
 package com.tencent.devops.auth.pojo.vo
 
+import com.tencent.devops.auth.pojo.enum.JoinedType
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(title = "权限诊断结果")
@@ -22,6 +23,8 @@ data class PermissionDiagnoseVO(
     val applicableGroups: List<ApplicableGroupVO> = emptyList(),
     @get:Schema(title = "用户组管理员（可联系申请）")
     val groupManagers: List<String> = emptyList(),
+    @get:Schema(title = "命中权限的来源用户组")
+    val permissionSourceGroups: List<PermissionSourceGroupVO> = emptyList(),
     @get:Schema(title = "建议操作")
     val suggestion: String? = null
 )
@@ -40,4 +43,24 @@ data class ApplicableGroupVO(
     val permissions: List<String> = emptyList(),
     @get:Schema(title = "推荐标签")
     val tags: List<PermissionTagVO> = emptyList()
+)
+
+@Schema(title = "权限来源用户组")
+data class PermissionSourceGroupVO(
+    @get:Schema(title = "用户组ID")
+    val groupId: Int,
+    @get:Schema(title = "用户组名称")
+    val groupName: String,
+    @get:Schema(title = "管理层级")
+    val managementLevel: String,
+    @get:Schema(title = "管理范围")
+    val managementScope: String,
+    @get:Schema(title = "加入方式")
+    val joinedType: JoinedType,
+    @get:Schema(title = "加入来源成员ID")
+    val joinedMemberId: String? = null,
+    @get:Schema(title = "加入来源成员名称")
+    val joinedMemberName: String? = null,
+    @get:Schema(title = "包含的权限列表")
+    val permissions: List<String> = emptyList()
 )

--- a/src/backend/ci/core/auth/api-auth/src/main/kotlin/com/tencent/devops/auth/pojo/vo/UserPermissionAnalysisVO.kt
+++ b/src/backend/ci/core/auth/api-auth/src/main/kotlin/com/tencent/devops/auth/pojo/vo/UserPermissionAnalysisVO.kt
@@ -1,5 +1,6 @@
 package com.tencent.devops.auth.pojo.vo
 
+import com.tencent.devops.auth.pojo.enum.JoinedType
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(title = "用户权限分析报告")
@@ -20,6 +21,28 @@ data class UserPermissionAnalysisVO(
     val totalAuthorizationCount: Long = 0,
     @get:Schema(title = "是否拥有项目全部权限")
     val hasAllPermissions: Boolean = false,
+    @get:Schema(title = "代表性的继承权限来源")
+    val inheritedGroups: List<InheritedGroupSummaryVO> = emptyList(),
     @get:Schema(title = "告警提示列表")
     val warnings: List<String> = emptyList()
+)
+
+@Schema(title = "继承权限来源摘要")
+data class InheritedGroupSummaryVO(
+    @get:Schema(title = "用户组ID")
+    val groupId: Int,
+    @get:Schema(title = "用户组名称")
+    val groupName: String,
+    @get:Schema(title = "资源类型")
+    val resourceType: String,
+    @get:Schema(title = "资源名称")
+    val resourceName: String,
+    @get:Schema(title = "管理层级")
+    val managementLevel: String,
+    @get:Schema(title = "加入方式")
+    val joinedType: JoinedType,
+    @get:Schema(title = "加入来源成员ID")
+    val joinedMemberId: String? = null,
+    @get:Schema(title = "加入来源成员名称")
+    val joinedMemberName: String? = null
 )

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/provider/rbac/service/RbacPermissionManageFacadeServiceImpl.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/provider/rbac/service/RbacPermissionManageFacadeServiceImpl.kt
@@ -360,6 +360,8 @@ class RbacPermissionManageFacadeServiceImpl(
 
                 else -> JoinedType.DIRECT
             },
+            joinedMemberId = authResourceGroupMember.memberId,
+            joinedMemberName = authResourceGroupMember.memberName,
             operator = "",
             beingHandedOver = groupsBeingHandover.map { it.itemId.toInt() }.contains(groupId),
             flowNo = groupsBeingHandover.firstOrNull { it.itemId.toInt() == groupId }?.flowNo,

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/provider/rbac/service/RbacPermissionResourceGroupSyncService.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/provider/rbac/service/RbacPermissionResourceGroupSyncService.kt
@@ -386,7 +386,7 @@ class RbacPermissionResourceGroupSyncService @Autowired constructor(
                 )
                 logger.info(
                     "It take(${System.currentTimeMillis() - startEpoch})ms to sync " +
-                        "project group and members $projectCode"
+                            "project group and members $projectCode"
                 )
             } catch (ex: Exception) {
                 handleException(
@@ -492,9 +492,9 @@ class RbacPermissionResourceGroupSyncService @Autowired constructor(
                 if (projectGroupMap.contains(iamGroupInfo.id)) {
                     val projectGroup = projectGroupMap[iamGroupInfo.id]!!
                     val isGroupInfoChanged = projectGroup.groupName != iamGroupInfo.name ||
-                        projectGroup.description != iamGroupInfo.description ||
-                        projectGroup.iamTemplateId != templateId ||
-                        projectGroup.applyDisable != iamGroupInfo.applyDisable
+                            projectGroup.description != iamGroupInfo.description ||
+                            projectGroup.iamTemplateId != templateId ||
+                            projectGroup.applyDisable != iamGroupInfo.applyDisable
                     if (isGroupInfoChanged) {
                         toUpdateGroups.add(
                             projectGroup.copy(
@@ -657,7 +657,7 @@ class RbacPermissionResourceGroupSyncService @Autowired constructor(
                     } catch (ignore: Exception) {
                         logger.warn(
                             "sync resource group member failed!" +
-                                "|$projectCode|${authResourceGroup.relationId}|$ignore"
+                                    "|$projectCode|${authResourceGroup.relationId}|$ignore"
                         )
                     }
                 }
@@ -759,7 +759,9 @@ class RbacPermissionResourceGroupSyncService @Autowired constructor(
         toDeleteMembers.addAll(resourceGroupMemberMap.filterKeys { !iamGroupMemberMap.contains(it) }.values)
         iamGroupMemberList.forEach { iamGroupMember ->
             val expiredTime = DateTimeUtil.convertTimestampToLocalDateTime(iamGroupMember.expiredAt)
-            val joinedAt = DateTimeUtil.convertTimestampToLocalDateTime(iamGroupMember.createdAt)
+            val joinedAt = iamGroupMember.createdAt?.let {
+                DateTimeUtil.convertTimestampToLocalDateTime(it)
+            }
             if (resourceGroupMemberMap.contains(iamGroupMember.id)) {
                 val resourceGroupMember = resourceGroupMemberMap[iamGroupMember.id]!!
                 if (expiredTime != resourceGroupMember.expiredTime || joinedAt != resourceGroupMember.joinedAt) {
@@ -813,7 +815,9 @@ class RbacPermissionResourceGroupSyncService @Autowired constructor(
         toDeleteMembers.addAll(resourceGroupMemberMap.filterKeys { !iamGroupTemplateMap.contains(it) }.values)
         iamGroupTemplateList.forEach { iamGroupTemplate ->
             val expiredTime = DateTimeUtil.convertTimestampToLocalDateTime(iamGroupTemplate.expiredAt)
-            val joinedAt = DateTimeUtil.convertTimestampToLocalDateTime(iamGroupTemplate.createdAt)
+            val joinedAt = iamGroupTemplate.createdAt?.let {
+                DateTimeUtil.convertTimestampToLocalDateTime(it)
+            }
             if (resourceGroupMemberMap.contains(iamGroupTemplate.id)) {
                 val resourceGroupMember = resourceGroupMemberMap[iamGroupTemplate.id]!!
                 if (expiredTime != resourceGroupMember.expiredTime || joinedAt != resourceGroupMember.joinedAt) {

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
@@ -1149,26 +1149,20 @@ class AuthAiServiceImpl(
             uniqueManagerGroupsQueryFlag = null
         )
         val totalGroupCount = groupCounts.sumOf { it.count }
-        val effectiveGroupIds = permissionResourceMemberService.getMemberGroupsInProject(projectId, memberId).toSet()
-        val inheritedGroups = if (effectiveGroupIds.isEmpty()) {
-            emptyList()
-        } else {
-            permissionManageFacadeService.getMemberGroupsDetails(
-                projectId = projectId,
-                memberId = memberId,
-                iamGroupIds = effectiveGroupIds.toList(),
-                operateChannel = OperateChannel.PERSONAL,
-                start = 0,
-                limit = MAX_EXPLANATION_GROUPS
-            ).records
-                .filter { it.joinedType != JoinedType.DIRECT }
-                .map(::toInheritedGroupSummary)
-                .sortedWith(
-                    compareByDescending<InheritedGroupSummaryVO> { it.joinedType == JoinedType.DEPARTMENT }
-                        .thenByDescending { levelSortOrder(it.managementLevel) }
-                        .thenBy { it.groupName }
-                )
-        }
+        val inheritedGroups = permissionManageFacadeService.getMemberGroupsDetails(
+            projectId = projectId,
+            memberId = memberId,
+            operateChannel = OperateChannel.PERSONAL,
+            start = 0,
+            limit = MAX_EXPLANATION_GROUPS
+        ).records
+            .filter { it.joinedType != JoinedType.DIRECT }
+            .map(::toInheritedGroupSummary)
+            .sortedWith(
+                compareByDescending<InheritedGroupSummaryVO> { it.joinedType == JoinedType.DEPARTMENT }
+                    .thenByDescending { levelSortOrder(it.managementLevel) }
+                    .thenBy { it.groupName }
+            )
         val resourceSummary = groupCounts.map { countVo ->
             ResourceSummaryVO(
                 resourceType = countVo.resourceType,
@@ -1653,10 +1647,6 @@ class AuthAiServiceImpl(
         if (matchingGroupIds.isEmpty()) {
             return emptyList()
         }
-        val effectiveGroupIds = permissionResourceMemberService.getMemberGroupsInProject(projectId, memberId).toSet()
-        if (effectiveGroupIds.isEmpty()) {
-            return emptyList()
-        }
         val matchedGroupDetails = permissionManageFacadeService.getMemberGroupsDetails(
             projectId = projectId,
             memberId = memberId,
@@ -1667,7 +1657,7 @@ class AuthAiServiceImpl(
             operateChannel = OperateChannel.PERSONAL,
             start = 0,
             limit = MAX_EXPLANATION_GROUPS
-        ).records.filter { it.groupId in effectiveGroupIds }
+        ).records
         if (matchedGroupDetails.isEmpty()) {
             return emptyList()
         }

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
@@ -165,7 +165,6 @@ class AuthAiServiceImpl(
         val permissionSourceGroups = buildPermissionSourceGroups(
             projectId = projectId,
             memberId = memberId,
-            matchingGroupIds = matchingGroupIds,
             relatedResourceType = resourceType,
             relatedResourceCode = resourceCode,
             action = action
@@ -1639,18 +1638,13 @@ class AuthAiServiceImpl(
     private fun buildPermissionSourceGroups(
         projectId: String,
         memberId: String,
-        matchingGroupIds: List<Int>,
         relatedResourceType: String,
         relatedResourceCode: String,
         action: String
     ): List<PermissionSourceGroupVO> {
-        if (matchingGroupIds.isEmpty()) {
-            return emptyList()
-        }
         val matchedGroupDetails = permissionManageFacadeService.getMemberGroupsDetails(
             projectId = projectId,
             memberId = memberId,
-            iamGroupIds = matchingGroupIds,
             relatedResourceType = relatedResourceType,
             relatedResourceCode = relatedResourceCode,
             action = action,

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
@@ -225,11 +225,7 @@ class AuthAiServiceImpl(
             missingReason = "用户未加入包含该权限的用户组",
             applicableGroups = applicableGroups,
             groupManagers = emptyList(),
-            suggestion = if (applicableGroups.isNotEmpty()) {
-                "建议申请加入「${applicableGroups.first().groupName}」用户组"
-            } else {
-                "暂无可申请的用户组，请联系项目管理员"
-            }
+            suggestion = buildDiagnosePermissionSuggestion(applicableGroups)
         )
     }
 
@@ -1220,7 +1216,7 @@ class AuthAiServiceImpl(
             authorizationSummary = authorizationSummary,
             totalAuthorizationCount = totalAuthorizationCount,
             hasAllPermissions = targetIsAdmin,
-            inheritedGroups = inheritedGroups.take(MAX_INHERITED_GROUPS_IN_ANALYSIS),
+            inheritedGroups = inheritedGroups,
             warnings = warnings
         )
     }
@@ -1440,8 +1436,7 @@ class AuthAiServiceImpl(
         MemberGroupJoinedDTO(id = it, memberType = MemberType.USER)
     }
 
-    private fun String.toResourceMemberInfo() =
-        ResourceMemberInfo(id = this, type = USER_TYPE)
+    private fun String.toResourceMemberInfo() = ResourceMemberInfo(id = this, type = USER_TYPE)
 
     private fun buildRecommendedCandidates(
         userId: String,
@@ -1715,6 +1710,28 @@ class AuthAiServiceImpl(
         else -> if (managementLevel.endsWith("组")) 1 else 0
     }
 
+    private fun buildDiagnosePermissionSuggestion(applicableGroups: List<ApplicableGroupVO>): String {
+        if (applicableGroups.isEmpty()) {
+            return "暂无可申请的用户组，请联系项目管理员"
+        }
+        if (applicableGroups.size == 1) {
+            return "建议申请加入「${applicableGroups.first().groupName}」用户组"
+        }
+        val recommendedGroups = applicableGroups.filter { group ->
+            group.tags.any { it.type == PermissionTagType.RECOMMEND }
+        }
+        return when {
+            recommendedGroups.size == 1 ->
+                "建议按最小权限原则申请加入「${recommendedGroups.first().groupName}」用户组"
+            recommendedGroups.isNotEmpty() -> {
+                val groupNames = recommendedGroups.take(3).joinToString("、") { "「${it.groupName}」" }
+                val suffix = if (recommendedGroups.size > 3) "等" else ""
+                "建议按最小权限原则，优先从以下资源级用户组中选择申请：$groupNames$suffix"
+            }
+            else -> "建议按最小权限原则开通，优先加入资源级别的用户组（详见可申请用户组列表）"
+        }
+    }
+
     private fun buildRecommendationTags(
         groupResourceType: String,
         requestedResourceType: String
@@ -1750,10 +1767,9 @@ class AuthAiServiceImpl(
     companion object {
         private val logger = LoggerFactory.getLogger(AuthAiServiceImpl::class.java)
         private const val DEFAULT_EXPIRED_DAYS = 365L
-        private const val MAX_CLONE_GROUPS = 500
-        private const val MAX_COMPARE_GROUPS = 500
-        private const val MAX_EXPLANATION_GROUPS = 500
-        private const val MAX_INHERITED_GROUPS_IN_ANALYSIS = 10
+        private const val MAX_CLONE_GROUPS = 1000
+        private const val MAX_COMPARE_GROUPS = 1000
+        private const val MAX_EXPLANATION_GROUPS = 1000
         private const val USER_TYPE = "user"
     }
 }

--- a/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
+++ b/src/backend/ci/core/auth/biz-auth/src/main/kotlin/com/tencent/devops/auth/service/AuthAiServiceImpl.kt
@@ -42,6 +42,7 @@ import com.tencent.devops.auth.pojo.dto.IamGroupIdsQueryConditionDTO
 import com.tencent.devops.auth.pojo.dto.MemberGroupJoinedDTO
 import com.tencent.devops.auth.pojo.dto.ResourceGroupPermissionDTO
 import com.tencent.devops.auth.pojo.enum.BatchOperateType
+import com.tencent.devops.auth.pojo.enum.JoinedType
 import com.tencent.devops.auth.pojo.enum.MemberType
 import com.tencent.devops.auth.pojo.enum.OperateChannel
 import com.tencent.devops.auth.pojo.enum.PermissionTagType
@@ -72,11 +73,13 @@ import com.tencent.devops.auth.pojo.vo.GroupCloneInfoVO
 import com.tencent.devops.auth.pojo.vo.GroupDetailsInfoVo
 import com.tencent.devops.auth.pojo.vo.GroupRecommendationVO
 import com.tencent.devops.auth.pojo.vo.HandoverCandidateVO
+import com.tencent.devops.auth.pojo.vo.InheritedGroupSummaryVO
 import com.tencent.devops.auth.pojo.vo.MemberExitCheckVO
 import com.tencent.devops.auth.pojo.vo.PermissionCloneResultVO
 import com.tencent.devops.auth.pojo.vo.PermissionCompareSummaryVO
 import com.tencent.devops.auth.pojo.vo.PermissionCompareVO
 import com.tencent.devops.auth.pojo.vo.PermissionDiagnoseVO
+import com.tencent.devops.auth.pojo.vo.PermissionSourceGroupVO
 import com.tencent.devops.auth.pojo.vo.PermissionTagVO
 import com.tencent.devops.auth.pojo.vo.ResolvedUserByNameVO
 import com.tencent.devops.auth.pojo.vo.ResourceGroupMatrixVO
@@ -152,8 +155,6 @@ class AuthAiServiceImpl(
             .firstOrNull { it.action == action }
         val actionName = actionInfo?.actionName ?: action
 
-        val memberGroups = permissionResourceMemberService.getMemberGroupsInProject(projectId, memberId).toSet()
-
         val matchingGroupIds = permissionResourceGroupPermissionService.listGroupsByPermissionConditions(
             projectCode = projectId,
             relatedResourceType = resourceType,
@@ -161,7 +162,15 @@ class AuthAiServiceImpl(
             action = action
         )
 
-        val hasPermission = matchingGroupIds.any { it in memberGroups }
+        val permissionSourceGroups = buildPermissionSourceGroups(
+            projectId = projectId,
+            memberId = memberId,
+            matchingGroupIds = matchingGroupIds,
+            relatedResourceType = resourceType,
+            relatedResourceCode = resourceCode,
+            action = action
+        )
+        val hasPermission = permissionSourceGroups.isNotEmpty()
 
         if (hasPermission) {
             return PermissionDiagnoseVO(
@@ -171,7 +180,8 @@ class AuthAiServiceImpl(
                 resourceName = resourceName,
                 action = action,
                 actionName = actionName,
-                suggestion = "用户已拥有该权限"
+                permissionSourceGroups = permissionSourceGroups,
+                suggestion = "用户已拥有该权限，可按来源用户组继续核对继承链路"
             )
         }
 
@@ -1124,7 +1134,7 @@ class AuthAiServiceImpl(
         if (!isAdmin && userId != memberId) {
             throw PermissionForbiddenException("非管理员不能查看其他成员的权限分析")
         }
-        val channel = if (isAdmin) OperateChannel.MANAGER else OperateChannel.PERSONAL
+        val channel = OperateChannel.PERSONAL
         val targetIsAdmin = permissionProjectService.checkProjectManager(memberId, projectId)
         val groupCounts = permissionManageFacadeService.getMemberGroupsCount(
             projectCode = projectId,
@@ -1139,6 +1149,26 @@ class AuthAiServiceImpl(
             uniqueManagerGroupsQueryFlag = null
         )
         val totalGroupCount = groupCounts.sumOf { it.count }
+        val effectiveGroupIds = permissionResourceMemberService.getMemberGroupsInProject(projectId, memberId).toSet()
+        val inheritedGroups = if (effectiveGroupIds.isEmpty()) {
+            emptyList()
+        } else {
+            permissionManageFacadeService.getMemberGroupsDetails(
+                projectId = projectId,
+                memberId = memberId,
+                iamGroupIds = effectiveGroupIds.toList(),
+                operateChannel = OperateChannel.PERSONAL,
+                start = 0,
+                limit = MAX_EXPLANATION_GROUPS
+            ).records
+                .filter { it.joinedType != JoinedType.DIRECT }
+                .map(::toInheritedGroupSummary)
+                .sortedWith(
+                    compareByDescending<InheritedGroupSummaryVO> { it.joinedType == JoinedType.DEPARTMENT }
+                        .thenByDescending { levelSortOrder(it.managementLevel) }
+                        .thenBy { it.groupName }
+                )
+        }
         val resourceSummary = groupCounts.map { countVo ->
             ResourceSummaryVO(
                 resourceType = countVo.resourceType,
@@ -1180,6 +1210,14 @@ class AuthAiServiceImpl(
         if (expiredGroupCount > 0) {
             warnings.add("$expiredGroupCount 个用户组的权限已过期，可清理")
         }
+        val departmentInheritedCount = inheritedGroups.count { it.joinedType == JoinedType.DEPARTMENT }
+        if (departmentInheritedCount > 0) {
+            warnings.add("存在 $departmentInheritedCount 个通过组织继承的用户组，请重点核对高权限范围")
+        }
+        val templateInheritedCount = inheritedGroups.count { it.joinedType == JoinedType.TEMPLATE }
+        if (templateInheritedCount > 0) {
+            warnings.add("存在 $templateInheritedCount 个通过模板继承的用户组")
+        }
         return UserPermissionAnalysisVO(
             role = if (targetIsAdmin) "MANAGER" else "MEMBER",
             roleDisplayName = if (targetIsAdmin) "项目管理员" else "项目成员",
@@ -1189,6 +1227,7 @@ class AuthAiServiceImpl(
             authorizationSummary = authorizationSummary,
             totalAuthorizationCount = totalAuthorizationCount,
             hasAllPermissions = targetIsAdmin,
+            inheritedGroups = inheritedGroups.take(MAX_INHERITED_GROUPS_IN_ANALYSIS),
             warnings = warnings
         )
     }
@@ -1603,6 +1642,80 @@ class AuthAiServiceImpl(
         }
     }
 
+    private fun buildPermissionSourceGroups(
+        projectId: String,
+        memberId: String,
+        matchingGroupIds: List<Int>,
+        relatedResourceType: String,
+        relatedResourceCode: String,
+        action: String
+    ): List<PermissionSourceGroupVO> {
+        if (matchingGroupIds.isEmpty()) {
+            return emptyList()
+        }
+        val effectiveGroupIds = permissionResourceMemberService.getMemberGroupsInProject(projectId, memberId).toSet()
+        if (effectiveGroupIds.isEmpty()) {
+            return emptyList()
+        }
+        val matchedGroupDetails = permissionManageFacadeService.getMemberGroupsDetails(
+            projectId = projectId,
+            memberId = memberId,
+            iamGroupIds = matchingGroupIds,
+            relatedResourceType = relatedResourceType,
+            relatedResourceCode = relatedResourceCode,
+            action = action,
+            operateChannel = OperateChannel.PERSONAL,
+            start = 0,
+            limit = MAX_EXPLANATION_GROUPS
+        ).records.filter { it.groupId in effectiveGroupIds }
+        if (matchedGroupDetails.isEmpty()) {
+            return emptyList()
+        }
+        val permissionsByGroup = authResourceGroupPermissionDao.listByGroupIds(
+            dslContext = dslContext,
+            projectCode = projectId,
+            iamGroupIds = matchedGroupDetails.map { it.groupId }
+        ).groupBy { it.iamGroupId }
+        return matchedGroupDetails.map { group ->
+            PermissionSourceGroupVO(
+                groupId = group.groupId,
+                groupName = group.groupName,
+                managementLevel = resolveManagementLevel(group.resourceType),
+                managementScope = group.resourceName,
+                joinedType = group.joinedType,
+                joinedMemberId = group.joinedMemberId,
+                joinedMemberName = group.joinedMemberName,
+                permissions = resolvePermissionNames(permissionsByGroup[group.groupId].orEmpty())
+            )
+        }.sortedWith(
+            compareByDescending<PermissionSourceGroupVO> { it.joinedType == JoinedType.DEPARTMENT }
+                .thenByDescending { levelSortOrder(it.managementLevel) }
+                .thenBy { it.groupName }
+        )
+    }
+
+    private fun resolvePermissionNames(
+        permissions: List<ResourceGroupPermissionDTO>
+    ): List<String> {
+        return permissions.map { permission ->
+            runCatching { rbacCommonService.getActionInfo(permission.action).actionName }
+                .getOrElse { permission.action }
+        }.distinct()
+    }
+
+    private fun toInheritedGroupSummary(group: GroupDetailsInfoVo): InheritedGroupSummaryVO {
+        return InheritedGroupSummaryVO(
+            groupId = group.groupId,
+            groupName = group.groupName,
+            resourceType = group.resourceType,
+            resourceName = group.resourceName,
+            managementLevel = resolveManagementLevel(group.resourceType),
+            joinedType = group.joinedType,
+            joinedMemberId = group.joinedMemberId,
+            joinedMemberName = group.joinedMemberName
+        )
+    }
+
     private fun resolveManagementLevel(resourceType: String): String = when {
         resourceType == "project" -> "项目"
         resourceType.endsWith("_group") ->
@@ -1655,6 +1768,8 @@ class AuthAiServiceImpl(
         private const val DEFAULT_EXPIRED_DAYS = 365L
         private const val MAX_CLONE_GROUPS = 500
         private const val MAX_COMPARE_GROUPS = 500
+        private const val MAX_EXPLANATION_GROUPS = 500
+        private const val MAX_INHERITED_GROUPS_IN_ANALYSIS = 10
         private const val USER_TYPE = "user"
     }
 }


### PR DESCRIPTION
变更背景
当前蓝盾智能助手在权限分析场景下，虽然能判断用户是否有权限，但对于“间接继承权限”的来源解释不够完整。比如用户通过组织/部门加入用户组，或者通过用户组模板间接继承到其他用户组权限时，助手通常只能回答“已有权限”，无法明确说明具体继承链路，影响权限排查和问题定位效率。

变更内容
本次增强主要补齐权限来源解释能力。扩展了权限诊断和用户权限分析的返回信息，支持透出用户组加入方式及来源对象，覆盖直接加入、组织/部门继承、模板继承三类场景。同步优化了智能助手输出文案，让其在分析时能够直接说明“来源对象 -> 用户组 -> 权限范围/动作”的继承关系。