### PR TITLE
feat: 新增根据条件查询项目成员的 apigw 接口

### DIFF
--- a/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/api/apigw/v4/ApigwAuthMemberManageResourceV4.kt
+++ b/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/api/apigw/v4/ApigwAuthMemberManageResourceV4.kt
@@ -76,6 +76,45 @@ interface ApigwAuthMemberManageResourceV4 {
     ): Result<SQLPage<AuthResourceGroup>>
 
     @GET
+    @Path("/list_project_members")
+    @Operation(
+        summary = "根据条件查询项目成员",
+        tags = ["v4_app_list_project_members", "v4_user_list_project_members"]
+    )
+    fun listProjectMembers(
+        @Parameter(description = "应用Code(OpenAPI调用方标识)", required = true, example = AUTH_HEADER_DEVOPS_APP_CODE_DEFAULT_VALUE)
+        @HeaderParam(AUTH_HEADER_DEVOPS_APP_CODE)
+        appCode: String?,
+        @Parameter(description = "网关类型,取值为apigw-user、apigw-app或apigw", required = true)
+        @PathParam("apigwType")
+        apigwType: String?,
+        @Parameter(description = "操作人用户ID", required = true)
+        @HeaderParam(AUTH_HEADER_DEVOPS_USER_ID)
+        userId: String,
+        @Parameter(description = "项目ID(项目英文名)", required = true)
+        @PathParam("projectId")
+        projectId: String,
+        @Parameter(description = "成员类型(user-用户/department-部门)")
+        @QueryParam("memberType")
+        memberType: String?,
+        @Parameter(description = "成员名称(用户ID或部门名称,支持模糊匹配)")
+        @QueryParam("userName")
+        userName: String?,
+        @Parameter(description = "部门名称")
+        @QueryParam("deptName")
+        deptName: String?,
+        @Parameter(description = "是否包含已离职成员")
+        @QueryParam("departedFlag")
+        departedFlag: Boolean?,
+        @Parameter(description = "第几页", required = true)
+        @QueryParam("page")
+        page: Int,
+        @Parameter(description = "每页数量", required = true)
+        @QueryParam("pageSize")
+        pageSize: Int
+    ): Result<SQLPage<ResourceMemberInfo>>
+
+    @GET
     @Path("/groups/{groupId}/permission_detail")
     @Operation(
         summary = "查询用户组权限详情",

--- a/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/resources/apigw/v4/ApigwAuthMemberManageResourceV4Impl.kt
+++ b/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/resources/apigw/v4/ApigwAuthMemberManageResourceV4Impl.kt
@@ -2,6 +2,7 @@ package com.tencent.devops.openapi.resources.apigw.v4
 
 import com.tencent.devops.auth.api.service.ServiceAuthAiResource
 import com.tencent.devops.auth.api.service.ServiceAuthApplyResource
+import com.tencent.devops.auth.api.service.ServiceResourceMemberResource
 import com.tencent.devops.auth.pojo.AuthResourceGroup
 import com.tencent.devops.auth.pojo.AuthResourceGroupMember
 import com.tencent.devops.auth.pojo.ResourceMemberInfo
@@ -56,6 +57,30 @@ class ApigwAuthMemberManageResourceV4Impl @Autowired constructor(
             userId = userId,
             projectId = projectId,
             condition = condition.copy(projectCode = projectId)
+        )
+    }
+
+    override fun listProjectMembers(
+        appCode: String?,
+        apigwType: String?,
+        userId: String,
+        projectId: String,
+        memberType: String?,
+        userName: String?,
+        deptName: String?,
+        departedFlag: Boolean?,
+        page: Int,
+        pageSize: Int
+    ): Result<SQLPage<ResourceMemberInfo>> {
+        logger.info("OPENAPI_AUTH_MEMBER_MANAGE_V4|$appCode|$userId|listProjectMembers|$projectId")
+        return client.get(ServiceResourceMemberResource::class).listProjectMembers(
+            projectCode = projectId,
+            memberType = memberType,
+            userName = userName,
+            deptName = deptName,
+            departedFlag = departedFlag,
+            page = page,
+            pageSize = pageSize
         )
     }
 


### PR DESCRIPTION
## 实现 / Implementation

新增 #13094 所需的「根据条件查询项目成员」apigw 接口：

- 在 `ApigwAuthMemberManageResourceV4` 中新增 `listProjectMembers`（`GET .../member_manage/list_project_members`），支持按 `memberType` / `userName` / `deptName` / `departedFlag` 条件 + 分页查询，返回 `Result<SQLPage<ResourceMemberInfo>>`。
- Impl 直接复用已有的 `ServiceResourceMemberResource.listProjectMembers`（即 `PermissionResourceMemberService.listProjectMembers`），按现有 `listGroups` 的网关委托模式实现，未新增业务逻辑。

---

Adds the apigw endpoint requested in #13094 to query project members by condition.

- **Interface** (`ApigwAuthMemberManageResourceV4`): new `listProjectMembers` — `GET .../member_manage/list_project_members`, filtering by `memberType` / `userName` / `deptName` / `departedFlag` with pagination, returning `Result<SQLPage<ResourceMemberInfo>>`.
- **Impl** (`ApigwAuthMemberManageResourceV4Impl`): delegates to the existing `ServiceResourceMemberResource.listProjectMembers`, mirroring the existing `listGroups` gateway pattern — no new service logic, it just exposes the existing query through the gateway.

### Verification
`./gradlew :core:openapi:api-openapi:compileKotlin` passes locally. The `biz-openapi` module isn't compilable locally because `model-openapi`'s jOOQ code generation needs a live database, but the impl is a 1:1 mirror of the existing delegation pattern and the `ServiceResourceMemberResource.listProjectMembers` signature matches exactly.

Since the issue didn't specify the exact conditions, I went with the parameters the existing `listProjectMembers` already supports — happy to adjust the contract if you'd prefer something different.

Closes #13094
