### PR TITLE
bug:运行条件为【只有前面有插件运行失败时才运行】的插件会导致前面失败的插件无法重试或者跳过 #13167

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/utils/ModelUtils.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/utils/ModelUtils.kt
@@ -131,13 +131,12 @@ object ModelUtils {
     }
 
     private fun refreshContainer(container: Container) {
-        val failElements = mutableListOf<Element>()
         container.elements.forEach { e ->
-            refreshElement(element = e, failElements = failElements)
+            refreshElement(element = e)
         }
     }
 
-    private fun refreshElement(element: Element, failElements: MutableList<Element>) {
+    private fun refreshElement(element: Element) {
 
         val additionalOptions = element.additionalOptions
         if (additionalOptions == null || !additionalOptions.enable) {
@@ -163,17 +162,9 @@ object ModelUtils {
             additionalOptions.runCondition == RunCondition.PRE_TASK_FAILED_BUT_CANCEL ||
             additionalOptions.runCondition == RunCondition.PRE_TASK_FAILED_EVEN_CANCEL
         ) {
-            // 前面有失败的插件时也要运行的插件，将前面的失败插件置为不可重试和跳过
+            // “失败时才运行”的插件自身不放开重试/跳过；但不再影响前序失败插件的重试/跳过按钮
             element.canRetry = null
             element.canSkip = null
-            failElements.forEach { // 只为了减少传输数据，置空不会被序列化出字段
-                it.canSkip = null
-                it.canRetry = null
-            }
-        }
-
-        if (element.canRetry == true) { // 先记录可重试的执行失败插件
-            failElements.add(element)
         }
     }
 

--- a/src/backend/ci/core/common/common-pipeline/src/test/kotlin/com/tencent/devops/common/pipeline/utils/ModelUtilsTest.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/test/kotlin/com/tencent/devops/common/pipeline/utils/ModelUtilsTest.kt
@@ -244,14 +244,14 @@ class ModelUtilsTest {
         resetElement(e2, failStatus)
         // 设置了手动重试，不允许跳过
         e1.additionalOptions = elementAdditionalOptions(manualRetry = true)
-        // 设置允许重试，并且前面有失败的也运行，将不会有任何跳过或重试的按钮
+        // e2 是“失败时才运行”的插件，自身不放开重试/跳过；但不再影响前序失败插件 e1 的按钮
         e2.additionalOptions = elementAdditionalOptions(
             runCondition = RunCondition.PRE_TASK_FAILED_BUT_CANCEL,
             manualRetry = true
         )
         ModelUtils.refreshCanRetry(model)
-        assertEquals(false, e1.canRetry ?: false) // e1是 受到e2 的永远不会出现 重试或跳过
-        assertEquals(false, e1.canSkip ?: false) // 第一个是 失败自动跳过, 永远不会出现 重试或跳过
+        assertEquals(true, e1.canRetry) // e1 普通失败插件 manualRetry=true，可重试，不再被 e2 清空
+        assertEquals(false, e1.canSkip ?: false) // 普通失败插件不放开跳过
         assertEquals(false, e2.canSkip ?: false)
         assertEquals(false, e2.canRetry ?: false)
 

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -196,10 +196,37 @@ data class StartBuildContext(
                 false
             }
 
+            // 单插件失败重试（非跳过失败插件）时，被重试插件之后、同Job内的后续插件也需要重新排队执行，
+            // 以便引擎重新评估其运行条件（如 PRE_TASK_FAILED_ONLY 等），避免重试后下游插件因不重跑而被遗漏
+            !skipFailedTask && isAfterRetryTaskInSameContainer(container, taskId) -> {
+                false
+            }
+
             else -> { // 当前插件不是要失败重试或要跳过的插件，会跳过
                 retryStartTaskId != taskId
             }
         }
+    }
+
+    /**
+     * 判断[taskId]对应的插件是否与要重试的插件[retryStartTaskId]处于同一个[container]，
+     * 且执行顺序排在其之后。用于单插件失败重试时一并重跑后续插件，从而重新评估运行条件。
+     * post-action 任务交由原有 post 重试逻辑处理，这里不纳入，避免误重跑前序插件的 post。
+     */
+    private fun isAfterRetryTaskInSameContainer(container: Container, taskId: String?): Boolean {
+        if (taskId.isNullOrBlank() || retryStartTaskId.isNullOrBlank()) {
+            return false
+        }
+        val elements = container.elements
+        val retryIndex = elements.indexOfFirst { it.id == retryStartTaskId }
+        if (retryIndex < 0) { // 要重试的插件不在当前容器（其它并行Job），保持原有跳过逻辑
+            return false
+        }
+        val currentElement = elements.firstOrNull { it.id == taskId } ?: return false
+        if (currentElement.additionalOptions?.elementPostInfo != null) { // post任务交由原有逻辑处理
+            return false
+        }
+        return elements.indexOf(currentElement) > retryIndex
     }
 
     fun inSkipStage(stage: Stage, atom: Element): Boolean {

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -196,9 +196,12 @@ data class StartBuildContext(
                 false
             }
 
-            // 单插件失败重试（非跳过失败插件）时，被重试插件之后、同Job内的后续插件也需要重新排队执行，
-            // 以便引擎重新评估其运行条件（如 PRE_TASK_FAILED_ONLY 等），避免重试后下游插件因不重跑而被遗漏
-            !skipFailedTask && isAfterRetryTaskInSameContainer(container, taskId) -> {
+            // 单插件失败重试/跳过时，被操作插件之后、同Job内的后续插件也需要重新排队，
+            // 以便引擎重新评估其运行条件（如 PRE_TASK_FAILED_ONLY 等）：
+            // 重试场景——被重试插件重跑后，下游按最新结果重新判定；
+            // 跳过场景——被跳过插件置为SKIP（不再算失败）后，下游同样需要据此重新判定，
+            // 否则仅因上游失败才执行过的下游插件（如失败通知）会保留旧的失败态，导致跳过后Job仍为失败。
+            isAfterRetryTaskInSameContainer(container, taskId) -> {
                 false
             }
 
@@ -209,8 +212,8 @@ data class StartBuildContext(
     }
 
     /**
-     * 判断[taskId]对应的插件是否与要重试的插件[retryStartTaskId]处于同一个[container]，
-     * 且执行顺序排在其之后。用于单插件失败重试时一并重跑后续插件，从而重新评估运行条件。
+     * 判断[taskId]对应的插件是否与被重试/跳过的插件[retryStartTaskId]处于同一个[container]，
+     * 且执行顺序排在其之后。用于单插件失败重试/跳过时一并重排后续插件，从而重新评估运行条件。
      * post-action 任务交由原有 post 重试逻辑处理，这里不纳入，避免误重跑前序插件的 post。
      */
     private fun isAfterRetryTaskInSameContainer(container: Container, taskId: String?): Boolean {

--- a/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/context/StartBuildContextTest.kt
+++ b/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/context/StartBuildContextTest.kt
@@ -179,6 +179,65 @@ class StartBuildContextTest : TestBase() {
     }
 
     @Test
+    fun needSkipTaskWhenRetryRerunDownstream() {
+        // 单插件失败重试（skipFailedTask=false）：被重试插件之后、同Job内的后续插件需要一并重排（不跳过）
+        val stages = genStages(stageSize = 2, jobSize = 2, elementSize = 3, needFinally = false)
+        val stage = stages[1]
+        val container = stage.containers[0]
+        val parallelContainer = stage.containers[1] // 同stage的并行Job
+        // 指定要重试的插件为容器中间那个
+        params[PIPELINE_RETRY_START_TASK_ID] = container.elements[1].id!!
+        val context = initDefaultStartBuildContext()
+
+        // 被重试插件本身：不跳过
+        Assertions.assertEquals(
+            false, context.needSkipTaskWhenRetry(stage, container, container.elements[1].id)
+        )
+        // 被重试插件之前的插件：保持原逻辑，跳过
+        Assertions.assertEquals(
+            true, context.needSkipTaskWhenRetry(stage, container, container.elements[0].id)
+        )
+        // 被重试插件之后的插件：新逻辑，需要重排（不跳过），以便重新评估运行条件
+        Assertions.assertEquals(
+            false, context.needSkipTaskWhenRetry(stage, container, container.elements[2].id)
+        )
+        // 其它并行Job的插件：不受影响，仍跳过
+        Assertions.assertEquals(
+            true, context.needSkipTaskWhenRetry(stage, parallelContainer, parallelContainer.elements[0].id)
+        )
+    }
+
+    @Test
+    fun needSkipTaskWhenSkipRerunDownstream() {
+        // 单插件跳过（skipFailedTask=true）：与重试对称，被跳过插件之后、同Job内的后续插件需要一并重排（不跳过）
+        params[PIPELINE_SKIP_FAILED_TASK] = true.toString()
+        val stages = genStages(stageSize = 2, jobSize = 2, elementSize = 3, needFinally = false)
+        val stage = stages[1]
+        val container = stage.containers[0]
+        val parallelContainer = stage.containers[1]
+        // 指定要跳过的插件为容器中间那个
+        params[PIPELINE_RETRY_START_TASK_ID] = container.elements[1].id!!
+        val context = initDefaultStartBuildContext()
+
+        // 被跳过插件本身：不属于"重试时跳过"（其SKIP由inSkipStage处理）
+        Assertions.assertEquals(
+            false, context.needSkipTaskWhenRetry(stage, container, container.elements[1].id)
+        )
+        // 被跳过插件之前的插件：保持原逻辑，跳过
+        Assertions.assertEquals(
+            true, context.needSkipTaskWhenRetry(stage, container, container.elements[0].id)
+        )
+        // 被跳过插件之后的插件：新逻辑，需要重排（不跳过），据此重新评估运行条件
+        Assertions.assertEquals(
+            false, context.needSkipTaskWhenRetry(stage, container, container.elements[2].id)
+        )
+        // 其它并行Job的插件：不受影响，仍跳过
+        Assertions.assertEquals(
+            true, context.needSkipTaskWhenRetry(stage, parallelContainer, parallelContainer.elements[0].id)
+        )
+    }
+
+    @Test
     fun inSkipStage() {
         // 跳过Stage-2下所有失败插件
         params[PIPELINE_RETRY_START_TASK_ID] = "stage-2"


### PR DESCRIPTION
bug:运行条件为【只有前面有插件运行失败时才运行】的插件会导致前面失败的插件无法重试或者跳过 #13167