### PR TITLE
fix: restore add trigger action for imported pipeline drafts

### DIFF
--- a/src/frontend/devops-pipeline/src/router/router.js
+++ b/src/frontend/devops-pipeline/src/router/router.js
@@ -96,7 +96,10 @@ const routes = [
                 children: [{
                     path: ':tab',
                     name: 'pipelineImportEdit',
-                    component: pipelinesEdit
+                    component: pipelinesEdit,
+                    meta: {
+                        edit: true
+                    }
                 }]
             },
             {


### PR DESCRIPTION
## Summary

- Set edit metadata on the imported pipeline draft edit route.
- Restore the add-trigger action in the trigger tab for drafts created from imported files.

## Root Cause

The import edit route reuses the pipeline edit page and trigger tab, but its child route did not expose edit metadata. `TriggerTab` uses that metadata to decide whether to render edit actions such as adding triggers.

## Validation

- Temporary regression assertion for `pipelineImportEdit` route metadata.
- `git diff --check github/master...HEAD`.

Fixes #13202
