### PR TITLE
fix: 流水线Code编辑模式无错误时空面板遮挡水平滚动条导致无法横向滚动与框选 #13232

### DIFF
--- a/src/frontend/devops-pipeline/src/components/YamlEditor.vue
+++ b/src/frontend/devops-pipeline/src/components/YamlEditor.vue
@@ -39,7 +39,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
         >
         </div>
         <ul
-            v-if="!readOnly"
+            v-if="!readOnly && errorList.length > 0"
             class="yaml-error-summary"
         >
             <li


### PR DESCRIPTION
## 问题
Closes #13232

在流水线 Code（YAML）编辑模式下，当某一行代码很长、出现横向溢出时，编辑器底部的水平滚动条无法拖动，也无法在长行上横向框选。

## 根因
`YamlEditor.vue` 中的错误信息面板 `.yaml-error-summary` 使用 `position: absolute; bottom: 0; width: 100%` 并带有内边距。此前该面板在非只读模式下始终渲染（仅以 `!readOnly` 作为条件）。当没有任何 YAML 错误时，空面板依然固定在底部并覆盖在 Monaco 水平滚动条之上，拦截了指针事件，导致无法拖动水平滚动条与横向框选。

## 修改
为该面板增加 `errorList.length > 0` 的渲染条件，仅在确实存在错误时才展示错误面板，避免空面板遮挡水平滚动条。

```diff
-            v-if="!readOnly"
+            v-if="!readOnly && errorList.length > 0"
```

## 验证
- ESLint 对改动文件无报错。
- 在 Code 编辑模式下输入超长行，确认底部水平滚动条可正常拖动、可横向框选；存在 YAML 错误时错误面板仍正常展示。

Made with [Cursor](https://cursor.com)