### PR TITLE
fix: 支持下载名称含特殊字符的制品 issue #13270

### DIFF
--- a/src/frontend/devops-pipeline/src/components/ArtifactDownloadButton.vue
+++ b/src/frontend/devops-pipeline/src/components/ArtifactDownloadButton.vue
@@ -51,6 +51,8 @@
 </template>
 
 <script>
+    import { encodeArtifactDownloadUrl } from '@/utils/util'
+
     export default {
         props: {
             downloadIcon: Boolean,
@@ -114,14 +116,15 @@
                             path: this.path
                         })
                     
-                    const result = await this.checkApkSigned(url2)
+                    const downloadUrl = encodeArtifactDownloadUrl(url2, this.path)
+                    const result = await this.checkApkSigned(downloadUrl)
                     if (result) {
-                        window.location.href = url2
+                        window.location.href = downloadUrl
                         return
                     } else {
                         this.signingMap.set(this.path, true)
                         this.setVisible(true)
-                        const result = await this.pollingCheckSignedApk(url2)
+                        const result = await this.pollingCheckSignedApk(downloadUrl)
                         if (result) {
                             this.setVisible(false)
                             this.$bkMessage({
@@ -129,7 +132,7 @@
                                 message: this.$t('apkSignSuccess', [this.name])
                             })
                             
-                            window.location.href = url2
+                            window.location.href = downloadUrl
                         }
                         this.signingMap.delete(this.path)
                     }

--- a/src/frontend/devops-pipeline/src/components/BuildHistoryTable/index.vue
+++ b/src/frontend/devops-pipeline/src/components/BuildHistoryTable/index.vue
@@ -631,7 +631,14 @@
         errorTypeMap,
         extForFile
     } from '@/utils/pipelineConst'
-    import { convertFileSize, convertMStoString, convertTime, flatSearchKey, copyToClipboard } from '@/utils/util'
+    import {
+        convertFileSize,
+        convertMStoString,
+        convertTime,
+        flatSearchKey,
+        copyToClipboard,
+        encodeArtifactDownloadUrl
+    } from '@/utils/util'
     import webSocketMessage from '@/utils/webSocketMessage'
     import { mapActions, mapGetters, mapState } from 'vuex'
 
@@ -1168,7 +1175,7 @@
                         message: `${this.$t('history.downloading')}${name}`,
                         theme: 'success'
                     })
-                    window.open(res.url, '_self')
+                    window.open(encodeArtifactDownloadUrl(res.url, path), '_self')
                 } catch (err) {
                     const { projectId, pipelineId } = this
                     this.handleError(err, {

--- a/src/frontend/devops-pipeline/src/utils/util.js
+++ b/src/frontend/devops-pipeline/src/utils/util.js
@@ -35,6 +35,19 @@ export function urlJoin (...args) {
     return args.filter(arg => arg).join('/').replace(/([^:]\/)\/+/g, '$1')
 }
 
+export function encodeArtifactDownloadUrl (url, path) {
+    const encodeSegment = segment => encodeURIComponent(segment).replace(
+        /[!'()*]/g,
+        char => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+    )
+    const encodedPath = path
+        .split('/')
+        .map(encodeSegment)
+        .join('/')
+
+    return url.replace(path, () => encodedPath)
+}
+
 export function isShallowEqual (obj1, obj2) {
     if (obj1 === obj2) return true
     if (!isObject(obj1) || !isObject(obj2)) {


### PR DESCRIPTION
关联 Issue：https://github.com/TencentBlueKing/bk-ci/issues/13270

## 变更摘要

- 对构建制品下载链接的路径部分按段进行 URL 编码，支持文件名包含 `#`、空格、`?`、`%`、`&`、`$`、中文等特殊字符。
- 保留下载链接已有的查询参数与签名参数，兼容 Devnet 与非 Devnet 网关地址。

## 验证

- `eslint devops-pipeline/src/components/ArtifactDownloadButton.vue devops-pipeline/src/components/BuildHistoryTable/index.vue devops-pipeline/src/utils/util.js`
- 本地调试验证通过。
- 已提送并在 develop 环境验证通过：`65bf45efdb0`。

## 风险说明

- 仅编码 URL 的路径部分；下载签名等查询参数保持不变。
