### PR TITLE
perf: 优化流水线组名称展示 issue #12943

### DIFF
--- a/src/frontend/devops-pipeline/src/views/PipelineList/PipelineGroupAside.vue
+++ b/src/frontend/devops-pipeline/src/views/PipelineList/PipelineGroupAside.vue
@@ -99,6 +99,11 @@
                                 v-model.trim="newViewName"
                             />
                             <span
+                                v-else-if="item.pac"
+                                v-start-ellipsis="item.name"
+                                class="pipeline-group-item-name pac-pipeline-group-item-name"
+                            />
+                            <span
                                 v-else
                                 class="pipeline-group-item-name"
                                 v-bk-overflow-tips
@@ -237,10 +242,86 @@
     } from '@/utils/permission'
     import { cacheViewId } from '@/utils/util'
     import { mapActions, mapGetters, mapState } from 'vuex'
+
+    // CSS 无法稳定实现多行头部省略，按容器宽度保留 PAC 分组名称的最长后缀。
+    const startEllipsisState = new WeakMap()
+
+    function updateStartEllipsis (el, text) {
+        const state = startEllipsisState.get(el)
+        if (!state) return
+
+        state.text = text ?? ''
+        if (state.frame) cancelAnimationFrame(state.frame)
+        state.frame = requestAnimationFrame(() => {
+            state.frame = null
+            el.textContent = state.text
+            el.removeAttribute('title')
+
+            if (!el.clientWidth || !state.text) return
+
+            const lineHeight = parseFloat(getComputedStyle(el).lineHeight)
+            if (!Number.isFinite(lineHeight)) return
+
+            const maxHeight = lineHeight * 2
+            if (el.scrollHeight <= maxHeight + 1) return
+
+            const characters = Array.from(state.text)
+            let start = 0
+            let end = characters.length
+            while (start < end) {
+                const middle = Math.floor((start + end) / 2)
+                el.textContent = `…${characters.slice(middle).join('')}`
+                if (el.scrollHeight <= maxHeight + 1) {
+                    end = middle
+                } else {
+                    start = middle + 1
+                }
+            }
+
+            el.textContent = `…${characters.slice(start).join('')}`
+            el.title = state.text
+        })
+    }
+
+    const startEllipsis = {
+        inserted (el, binding) {
+            const state = {
+                frame: null,
+                observer: null,
+                text: binding.value ?? ''
+            }
+            startEllipsisState.set(el, state)
+
+            if (typeof ResizeObserver === 'function') {
+                state.observer = new ResizeObserver(() => updateStartEllipsis(el, state.text))
+                state.observer.observe(el)
+            } else {
+                state.resizeHandler = () => updateStartEllipsis(el, state.text)
+                window.addEventListener('resize', state.resizeHandler)
+            }
+            updateStartEllipsis(el, state.text)
+        },
+        componentUpdated (el, binding) {
+            updateStartEllipsis(el, binding.value)
+        },
+        unbind (el) {
+            const state = startEllipsisState.get(el)
+            if (!state) return
+
+            if (state.frame) cancelAnimationFrame(state.frame)
+            state.observer?.disconnect()
+            if (state.resizeHandler) window.removeEventListener('resize', state.resizeHandler)
+            startEllipsisState.delete(el)
+        }
+    }
+
     export default {
         components: {
             Logo,
             ExtMenu
+        },
+        directives: {
+            startEllipsis
         },
         data () {
             return {
@@ -767,6 +848,16 @@
             .pipeline-group-item-name {
                 flex: 1;
                 @include ellipsis();
+
+                &.pac-pipeline-group-item-name {
+                    display: block;
+                    min-width: 0;
+                    max-height: 40px;
+                    overflow: hidden;
+                    line-height: 20px;
+                    white-space: normal;
+                    word-break: break-all;
+                }
             }
             .pipeline-group-item-sum {
                 display: flex;


### PR DESCRIPTION
## 关联 Issue

Closes #12943

## 变更摘要

- PAC 流水线分组名称最多展示两行。
- 名称超出可用空间时省略开头，保留最长路径后缀。
- 监听侧栏宽度变化并重新计算展示内容；短名称和普通分组维持原有行为。
- 截断时保留完整名称提示，便于查看原始路径。

## 验证结果

- `./node_modules/.bin/eslint devops-pipeline/src/views/PipelineList/PipelineGroupAside.vue`
- `pnpm nx dll devops-pipeline`
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false ./node_modules/.bin/nx dev devops-pipeline`
- 本地 `/pipeline/` 入口返回 200，开发构建编译成功。
- develop 验证提交：`2999723561d`
- 2026-07-17 用户确认开发自测通过。

## 风险说明

- 仅修改 `devops-pipeline` 前端 PAC 分组名称展示，不涉及后端接口和数据结构。
- 省略内容按容器实际宽度计算；已覆盖侧栏宽度变化后的重新计算。
