### PR TITLE
fix: service list total excludes hidden services #13350

### DIFF
--- a/src/frontend/devops-nav/src/views/Home.vue
+++ b/src/frontend/devops-nav/src/views/Home.vue
@@ -232,13 +232,10 @@
         }
 
         get serviceCount (): number {
-            // 减去1是因为项目管理服务是隐藏的
-            const count = this.services.reduce((sum, service) => {
-                sum += (service.children.length - 1)
-                return sum
+            return this.services.reduce((sum, service) => {
+                const children = Array.isArray(service.children) ? service.children : []
+                return sum + children.filter(child => child.status !== 'planning').length
             }, 0)
-            // 我的项目服务不展示，所以减去1
-            return count - 1
         }
 
         updateShowAllService (show: boolean): void {


### PR DESCRIPTION
## Summary

- Make the console service total count use the same visibility rule as rendered service cards.
- Exclude services whose status is `planning` from the displayed total.
- Add a defensive fallback for missing `children` arrays.

## Validation

```bash
pnpm --filter devops-nav exec eslint src/views/Home.vue
```

## Issue

Closes #13350

## Risk

Low. The change only affects frontend service count calculation in `devops-nav`.
