### PR TITLE
bug：定时任务删除失效导致 Quartz RAMJobStore 内存泄漏

### DIFF
--- a/ai/skills/java-heap-dump-triage/SKILL.md
+++ b/ai/skills/java-heap-dump-triage/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: java-heap-dump-triage
+description: 分析 Java heap dump、.hprof 文件、Eclipse MAT HTML 报告、Leak Suspects zip、Class Histogram、Dominator Tree、GC 异常、JVM OOM 或内存泄漏问题，并把 retained heap 证据关联回 Java/Kotlin/Spring/Quartz 项目代码，产出中文的根因判断、修复方案、验证计划和故障复盘文档。适用于用户要求分析 dump/hprof/heap dump/MAT 报告、内存泄漏、OOM、retained heap、dominator tree、RAMJobStore、ThreadLocal 泄漏、缓存泄漏、classloader 泄漏，或要求结合仓库代码优化内存问题的场景。
+---
+
+# Java Heap Dump 排查
+
+## 目标
+
+把 heap dump 证据转成可落地的工程诊断。优先给出有证据支撑的窄根因，不要泛泛罗列 JVM 调优建议。
+
+## 排查流程
+
+1. 定位分析材料。
+   - 搜索 `.hprof`、`*Leak_Suspects*.zip`、`*System_Overview*.zip`、`*Top_Components*.zip`、`.threads`、`.index`、MAT 导出的 HTML 报告。
+   - 记录 dump 大小、报告生成时间。
+   - 如果 MAT 的 System Properties 可用，记录应用名、启动类、profile、JDK 版本、服务端口、classpath 里的模块信息。
+   - 如果只有原始 `.hprof`，不要停止；先用 Eclipse MAT 命令行生成报告。
+
+2. 如果没有 MAT 报告，从 `.hprof` 生成报告。
+   - 查找 MAT 命令行工具，例如 `ParseHeapDump.sh` 或 `MemoryAnalyzer`。
+   - 不要删除原始 `.hprof`；如果要模拟无报告状态，只移动或清理 `.index`、`.threads`、`*_Leak_Suspects.zip`、`*_System_Overview.zip`、`*_Top_Components.zip` 等派生文件。
+   - 用 `ParseHeapDump.sh <dump.hprof> org.eclipse.mat.api:suspects org.eclipse.mat.api:overview org.eclipse.mat.api:top_components` 生成三类报告。
+   - 预期产物通常与 dump 同目录同前缀：
+     - `<name>_Leak_Suspects.zip`
+     - `<name>_System_Overview.zip`
+     - `<name>_Top_Components.zip`
+     - `<name>.threads`
+     - `<name>*.index`
+   - 解析大 dump 时输出很多，日志可能被截断；以最终退出码和生成物为准。
+   - 关键阶段包括：Parsing heap dump、Writing threads、Processing object reachability、Calculating Dominator Tree、Leak Suspects、System Overview、Top Components。
+
+3. 优先读取 MAT 报告，而不是一上来硬啃原始 dump。
+   - 用 `unzip -l` 查看报告 zip 内容。
+   - 解压到唯一临时目录，不删除用户文件。
+   - 重点解析 `index.html`、`pages/Class_Histogram*.html`、`pages/Top_Consumers*.html`、`pages/Thread_Overview*.html`、`pages/System_Properties*.html`、Problem Suspect 页面。
+   - 从 HTML 中提取文本后，总结 top retained objects、class histogram、GC root 最短路径、线程栈、JVM/应用属性。
+
+4. 找 retained memory 的真正持有者。
+   - 优先看 retained heap 和 dominator tree，不要被 shallow heap 误导。
+   - 识别一到几个主要 accumulation point，例如 cache/map、scheduler/job store、queue、ThreadLocal、classloader、ORM/session、HTTP buffer、byte array、String、reactive queue。
+   - 记录具体数字：retained bytes、占比、对象数量、top classes、最短路径字段。
+
+5. 把 dump 里的类名关联回代码。
+   - 用 `rg` 搜索类名、包名、框架类型、关键字段、job/cache/listener/scheduler API、配置项。
+   - 阅读创建、刷新、删除、保留可疑对象的代码路径。
+   - 检查生命周期是否对称：add/remove、subscribe/unsubscribe、schedule/delete、cache put/evict、ThreadLocal set/remove、close/shutdown。
+   - 检查身份标识是否对称：key name、group/namespace、task id、project id、hash/md5、tenant、channel、shard。
+   - 检查启动或 reload 逻辑是否重复注册但没有清理。
+
+6. 形成可证伪的根因。
+   - 把 dump 证据和具体代码行为绑定起来。
+   - 解释对象为什么增长，以及为什么 GC 无法回收。
+   - 区分直接原因和长期风险。例如：`RAMJobStore` 持有 trigger 是直接证据；大规模使用 `RAMJobStore` 是扩展性风险；`deleteJob` 用错 group 才是更具体的代码缺陷。
+
+7. 给出修复方案。
+   - 如果发现明确 bug，第一修复应尽量小而精确。
+   - 写清楚文件、函数、修改前行为、修改后行为。
+   - 只有在有助于验证时才加日志或指标。
+   - 结构性风险作为二阶段优化，不要混在立即修复里。
+
+8. 验证。
+   - 对改动模块运行最窄范围的编译或测试。
+   - 能补测试时，优先补生命周期对称性的单元/集成测试。
+   - 线上验证要包含重启、重新 dump、指标和日志检查。
+
+9. 输出结论。
+   - 先给根因和修复方案。
+   - 附关键 MAT 数字证据表。
+   - 附代码链路和问题点。
+   - 如果对象保存在进程内存中，明确说明上线后是否需要重启。
+   - 证据不足时标注为“假设”或“需要进一步验证”，不要过度断言。
+
+## 常用命令
+
+查找 heap 相关文件：
+
+```bash
+find ~/Desktop -maxdepth 3 \( -iname '*.hprof' -o -iname '*dump*' -o -iname '*heap*' -o -iname '*Leak_Suspects*.zip' -o -iname '*System_Overview*.zip' -o -iname '*Top_Components*.zip' \) -print
+```
+
+查找本机 Eclipse MAT 命令行：
+
+```bash
+command -v ParseHeapDump.sh || true
+command -v MemoryAnalyzer || true
+find /Applications "$HOME" -maxdepth 5 \( -iname 'ParseHeapDump.sh' -o -iname 'MemoryAnalyzer' \) -print 2>/dev/null
+```
+
+从原始 hprof 生成 MAT 报告：
+
+```bash
+/Applications/MemoryAnalyzer.app/Contents/Eclipse/ParseHeapDump.sh \
+  /path/to/heap_dump.hprof \
+  org.eclipse.mat.api:suspects \
+  org.eclipse.mat.api:overview \
+  org.eclipse.mat.api:top_components
+```
+
+生成后确认产物：
+
+```bash
+find /path/to/dump-dir -maxdepth 1 \( \
+  -name 'heap_dump*.index' \
+  -o -name 'heap_dump.threads' \
+  -o -name 'heap_dump_*Suspects.zip' \
+  -o -name 'heap_dump_*Overview.zip' \
+  -o -name 'heap_dump_*Components.zip' \
+\) -print | sort
+```
+
+查看 MAT 报告 zip：
+
+```bash
+unzip -l /path/to/heap_dump_Leak_Suspects.zip | sed -n '1,160p'
+```
+
+安全提取 MAT HTML 文本：
+
+```bash
+TMP=/tmp/heap_report_$$
+mkdir -p "$TMP/leak" "$TMP/overview" "$TMP/top"
+unzip -q /path/to/heap_dump_Leak_Suspects.zip -d "$TMP/leak"
+unzip -q /path/to/heap_dump_System_Overview.zip -d "$TMP/overview"
+unzip -q /path/to/heap_dump_Top_Components.zip -d "$TMP/top"
+python3 - "$TMP" <<'PY'
+from pathlib import Path
+import html, re, sys
+base = Path(sys.argv[1])
+for p in base.rglob("*.html"):
+    if p.name.startswith(("Class_Histogram", "Top_Consumers", "Thread_Overview", "System_Properties")) or p.name == "index.html":
+        s = p.read_text(errors="ignore")
+        s = re.sub(r"<script.*?</script>|<style.*?</style>", "", s, flags=re.S|re.I)
+        s = re.sub(r"<[^>]+>", "\n", s)
+        lines = [html.unescape(x.strip()) for x in s.splitlines() if x.strip()]
+        print(f"\n===== {p.relative_to(base)} =====")
+        print("\n".join(lines[:180]))
+PY
+```
+
+按可疑类和 API 回查代码：
+
+```bash
+rg -n "Quartz|RAMJobStore|CronTrigger|scheduleJob|deleteJob|ThreadLocal|Cache|put\\(|evict|shutdown|close\\(" src -g '*.kt' -g '*.java' -g '*.yml' -g '*.yaml' -g '*.properties'
+```
+
+## 实测生成流程记录
+
+本技能沉淀自一次从原始 dump 重新生成报告的实测流程：
+
+1. 原始输入只保留 `/Users/greysonfang/Desktop/heap_dump.hprof`，大小约 `2.6G`。
+2. 先将已有 MAT 派生物移走，包括 `heap_dump*.index`、`heap_dump.threads`、`heap_dump_Leak_Suspects.zip`、`heap_dump_System_Overview.zip`、`heap_dump_Top_Components.zip`。
+3. 找到本机 MAT 命令：`/Applications/MemoryAnalyzer.app/Contents/Eclipse/ParseHeapDump.sh`。
+4. 执行：
+
+```bash
+/Applications/MemoryAnalyzer.app/Contents/Eclipse/ParseHeapDump.sh \
+  /Users/greysonfang/Desktop/heap_dump.hprof \
+  org.eclipse.mat.api:suspects \
+  org.eclipse.mat.api:overview \
+  org.eclipse.mat.api:top_components
+```
+
+5. MAT 先解析 hprof、生成 `.threads` 和索引，再计算 Dominator Tree，最后输出三个报告 zip。
+6. 本次生成的报告大小约为：
+   - `heap_dump_Leak_Suspects.zip`: `168K`
+   - `heap_dump_System_Overview.zip`: `140K`
+   - `heap_dump_Top_Components.zip`: `772K`
+7. `Top Components` 阶段日志可能极多，终端输出被截断是正常的；只要进程退出码为 `0` 且报告 zip 存在即可继续分析。
+
+## 诊断经验
+
+- 如果一个对象占据极高 retained heap，占用链路应从它的 dominator path 开始。
+- 如果 Class Histogram 里有大量集合 entry，先找持有这些 entry 的上层集合，不要优化 entry 类型本身。
+- 如果框架内部 store 占大头，重点查业务代码如何使用这个框架的生命周期 API。
+- 如果代码里有删除逻辑但对象仍堆积，优先比较创建、检查、删除时使用的 key/group/namespace 是否完全一致。
+- 如果 dump 显示很多线程，但 retained heap 主要在别处，不要把线程数当成根因，除非 ThreadLocal 或线程栈直接保留了大对象。
+- 如果 System Properties 能看到应用名、profile、classpath，要用它定位具体服务模块。
+
+## 输出模板
+
+除非用户要求其他格式，使用下面结构输出：
+
+```markdown
+# Java Heap Dump 排查结论
+
+## 现象
+- Dump / MAT 报告来源：
+- 主要 retained heap：
+- 关键对象数量：
+
+## 根因
+一句话结论。
+
+## 证据链
+| 证据 | 数值/位置 | 说明 |
+| --- | --- | --- |
+
+## 代码定位
+- 文件：
+- 调用链：
+- 问题点：
+
+## 修复方案
+1. 立即修复：
+2. 验证：
+3. 上线/重启：
+
+## 长期优化
+- 监控：
+- 架构/存储：
+- 测试：
+```
+
+## 案例参考
+
+如果 MAT 中出现 Quartz `RAMJobStore`、`QuartzSchedulerResources`、`CronTriggerImpl`、`CronExpression`、`TriggerWrapper`、`TreeMap$Entry` 或 `JobKey` 占据主要 retained heap，读取 `references/quartz-ramjobstore.md`。

--- a/ai/skills/java-heap-dump-triage/agents/openai.yaml
+++ b/ai/skills/java-heap-dump-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Java Heap Dump 排查"
+  short_description: "分析 Java heap dump，并把内存证据关联回代码。"
+  default_prompt: "分析这个 Java heap dump 或 MAT 报告，识别 retained memory 根因，结合项目代码定位问题，并给出中文修复方案和验证计划。"

--- a/ai/skills/java-heap-dump-triage/references/quartz-ramjobstore.md
+++ b/ai/skills/java-heap-dump-triage/references/quartz-ramjobstore.md
@@ -1,0 +1,57 @@
+# Quartz RAMJobStore Heap Dump 模式
+
+当 MAT 显示 `org.quartz.simpl.RAMJobStore`、`QuartzSchedulerResources`、`CronTriggerImpl`、`CronExpression`、`TriggerWrapper`、`TreeMap$Entry` 或 `JobKey` 占据主要 retained heap 时，使用本参考。
+
+## 典型现象
+
+常见证据：
+
+- `org.quartz.simpl.RAMJobStore` 是最大 retained heap 持有者。
+- `org.quartz.core.QuartzSchedulerResources` 出现在到 GC roots 的最短路径上。
+- `CronTriggerImpl`、`CronExpression`、`TriggerWrapper` 数量异常高。
+- `TreeMap$Entry`、`TreeMap`、`TreeSet`、`Integer` 数量高，通常是 Quartz 内部保存和排序 trigger fire time 产生的结构。
+- 线程栈可能只显示 `QuartzSchedulerThread.run()` 在等待。这个线程通常是保留路径，不一定是泄漏源头。
+
+## 代码检查点
+
+重点阅读 scheduler 封装类和所有调用点：
+
+1. `scheduleJob`、`addJob`、`rescheduleJob`、`deleteJob`、`unscheduleJob`、`checkExists`。
+2. Job 身份：job name、job group、trigger name、trigger group。
+3. Key 组成：project id、pipeline id、task id、cron md5/hash、tenant/shard/channel。
+4. Reload 逻辑：启动或周期性 reload 必须幂等。
+5. 删除/刷新事件：终止动作必须删除 add 时创建的同一个身份。
+6. 异常处理：add 失败要清理部分创建的 job，delete 失败要记录足够上下文。
+
+## 常见根因
+
+- `deleteJob(JobKey)` 使用了 trigger group，而不是 job group。
+- 使用 `unscheduleJob(TriggerKey)`，但代码期望 durable job 也一起消失。
+- add 路径使用新 key 格式，delete 路径仍使用旧 key 格式。
+- 周期性 reload 不断 schedule job，但没有检查或删除已存在 job。
+- 数据库中的无效/过期 timer record 没有从 Quartz 中移除。
+- 多个服务实例都使用 `RAMJobStore`，并各自加载全量定时任务。
+
+## 修复建议
+
+优先做最小生命周期对称修复：
+
+- 让 add/check/delete 使用同一个 `JobKey`。
+- 让 trigger 删除使用同一个 `TriggerKey`。
+- 删除失败时记录 delete result、key、group。
+- 增加一个小测试：使用内存 Quartz scheduler，add 后 check 为 true，delete 后 check 为 false。
+
+如果 trigger 数量本身确实很大：
+
+- 增加 job count 和 trigger count 指标。
+- 评估 JDBC JobStore，注意数据库压力、集群锁、misfire 策略。
+- 从业务层减少展开后的 cron trigger 数量。
+
+## 生产验证
+
+修复上线后：
+
+- 对使用 `RAMJobStore` 的服务做重启；历史残留 job 存在于进程内存里。
+- 对比 Quartz trigger 数量和数据库有效 timer 记录数乘以每条记录的 cron 表达式数。
+- 运行一段时间后重新导出 heap dump，确认 `RAMJobStore` 不再占据主要 retained heap。
+- 观察 delete miss、reload add count、expired timer cleanup 等日志。

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/plugin/trigger/timer/SchedulerManager.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/plugin/trigger/timer/SchedulerManager.kt
@@ -133,7 +133,11 @@ abstract class SchedulerManager {
     @Synchronized
     fun deleteJob(crontabId: String): Boolean {
         return try {
-            getScheduler().deleteJob(JobKey.jobKey(crontabId, this.getTriggerGroup()))
+            // 删除必须与 addJob/checkExists 使用相同的 jobGroup 构造 JobKey，否则删不到 job 导致残留
+            val jobGroup = this.getJobGroup()
+            val deleted = getScheduler().deleteJob(JobKey.jobKey(crontabId, jobGroup))
+            logger.info("SchedulerManager.deleteJob|crontabId=$crontabId|jobGroup=$jobGroup|deleted=$deleted")
+            deleted
         } catch (ignored: Exception) {
             logger.error("SchedulerManager.deleteJob fail! e:$ignored", ignored)
             false


### PR DESCRIPTION
### 问题描述

流水线定时任务在删除/过期时无法从 Quartz `RAMJobStore` 中真正移除，job/trigger 长期残留在 JVM 内存中，导致堆内存持续增长。

某次 heap dump 中 `org.quartz.simpl.RAMJobStore` 占用约 1.17GB（约 70% 堆），`CronTriggerImpl` / `TriggerWrapper` 各约 9.8 万个，远超数据库中的有效定时器数量。

### 根因

`SchedulerManager` 中三个方法使用的 group 不一致：

- `addJob` 存储 job 使用 `getJobGroup()`（`bkJobGroup`）
- `checkExists` 查询 job 使用 `getJobGroup()`（`bkJobGroup`）✅
- `deleteJob` 删除 job 却使用 `getTriggerGroup()`（`bkTriggerGroup`）❌

Quartz `RAMJobStore.removeJob(JobKey)` 完全按 `JobKey`(name + group) 匹配删除，且关联 trigger 通过 `triggersByJob`（以 job 的 key 为索引）删除。当 group 不一致时，job 与其 trigger 都无法命中，`deleteJob` 恒返回 false。表现为「checkExists 查得到、deleteJob 删不掉」，过期任务按 cron 反复触发且永不清理。

涉及文件：

- `src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/plugin/trigger/timer/SchedulerManager.kt`

### 影响链路

- `PipelineJobBean.execute` 过期清理（`PIPELINE_TIMER_EXPIRED`）删除失败 → job 残留并持续触发
- `PipelineTimerChangerListener` 删除动作失败 → 残留累积

### 复现现象 / 日志

- 同一个 comboKey 的 `PIPELINE_TIMER_EXPIRED` 日志周期性反复出现（正常应只出现一次即停止）
- 同一 jobKey 的 `clear residual scheduled tasks` 反复出现
- heap dump 中 Quartz trigger 数量远大于数据库有效定时器数量

### 修复方案

将 `deleteJob` 改用 `getJobGroup()` 构造 `JobKey`，与 `addJob` / `checkExists` 保持一致；并在 `deleteJob` 增加删除结果日志（`deleted=true/false`）便于线上观测。

### 备注

上线后需重启 process 服务以释放历史残留在内存中的 Quartz job/trigger。