### PR TITLE
bug: 修复webhook构建参数溢出处理 - 应丢弃大型环境变量而非整个载荷 #13356

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/WebhookBuildParameterService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/WebhookBuildParameterService.kt
@@ -26,7 +26,7 @@ class WebhookBuildParameterService @Autowired constructor(
         buildParameters: List<BuildParameters>
     ) {
         var parameters = buildParameters
-        var json = JsonUtil.toJson(parameters)
+        var json = JsonUtil.toJson(parameters, false)
         if (json.toByteArray(Charsets.UTF_8).size > WEBHOOK_BUILD_PARAMETER_LENGTH_MAX) {
             // 过滤按提交/文件累加的超大批量变量，保留其余有效参数，避免整体丢弃导致重试时变量缺失
             val filtered = parameters.filter { param ->
@@ -38,7 +38,7 @@ class WebhookBuildParameterService @Autowired constructor(
                     "buildId: $buildId|drop oversized params: $droppedKeys"
             )
             parameters = filtered
-            json = JsonUtil.toJson(parameters)
+            json = JsonUtil.toJson(parameters, false)
         }
         // 极端情况下过滤后仍超长，跳过保存避免 DB 写入失败
         if (json.toByteArray(Charsets.UTF_8).size > WEBHOOK_BUILD_PARAMETER_LENGTH_MAX) {

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/WebhookBuildParameterService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/WebhookBuildParameterService.kt
@@ -3,6 +3,10 @@ package com.tencent.devops.process.engine.service
 import com.fasterxml.jackson.core.type.TypeReference
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.pipeline.pojo.BuildParameters
+import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_PUSH_ADD_FILE_PREFIX
+import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_PUSH_COMMIT_PREFIX
+import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_PUSH_DELETE_FILE_PREFIX
+import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_PUSH_MODIFY_FILE_PREFIX
 import com.tencent.devops.process.engine.dao.WebhookBuildParameterDao
 import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
@@ -21,9 +25,27 @@ class WebhookBuildParameterService @Autowired constructor(
         buildId: String,
         buildParameters: List<BuildParameters>
     ) {
-        val json = JsonUtil.toJson(buildParameters)
+        var parameters = buildParameters
+        var json = JsonUtil.toJson(parameters)
         if (json.toByteArray(Charsets.UTF_8).size > WEBHOOK_BUILD_PARAMETER_LENGTH_MAX) {
-            logger.info("webhook build parameter length is too long, length: ${json.length}|skip save")
+            // 过滤按提交/文件累加的超大批量变量，保留其余有效参数，避免整体丢弃导致重试时变量缺失
+            val filtered = parameters.filter { param ->
+                OVERSIZED_PARAMETER_PREFIXES.none { param.key.startsWith(it) }
+            }
+            val droppedKeys = parameters.map { it.key } - filtered.map { it.key }.toSet()
+            logger.warn(
+                "webhook build parameter too long, length: ${json.length}, " +
+                    "buildId: $buildId|drop oversized params: $droppedKeys"
+            )
+            parameters = filtered
+            json = JsonUtil.toJson(parameters)
+        }
+        // 极端情况下过滤后仍超长，跳过保存避免 DB 写入失败
+        if (json.toByteArray(Charsets.UTF_8).size > WEBHOOK_BUILD_PARAMETER_LENGTH_MAX) {
+            logger.warn(
+                "webhook build parameter still too long after filtering, " +
+                    "length: ${json.length}, buildId: $buildId|skip save"
+            )
             return
         }
         webhookBuildParameterDao.save(
@@ -47,5 +69,13 @@ class WebhookBuildParameterService @Autowired constructor(
     companion object {
         private val logger = LoggerFactory.getLogger(WebhookBuildParameterService::class.java)
         const val WEBHOOK_BUILD_PARAMETER_LENGTH_MAX = 65535
+
+        // 按提交/文件数量累加的批量变量前缀，超长时优先过滤
+        private val OVERSIZED_PARAMETER_PREFIXES = listOf(
+            BK_REPO_GIT_WEBHOOK_PUSH_COMMIT_PREFIX, // 含 COMMIT_MSG_/TIMESTAMP_/AUTHOR_ 子前缀
+            BK_REPO_GIT_WEBHOOK_PUSH_ADD_FILE_PREFIX,
+            BK_REPO_GIT_WEBHOOK_PUSH_MODIFY_FILE_PREFIX,
+            BK_REPO_GIT_WEBHOOK_PUSH_DELETE_FILE_PREFIX
+        )
     }
 }


### PR DESCRIPTION
#13356