### PR TITLE
feat: 人工审核勾选企业微信群消息时自动@审核人 #13382

### DIFF
--- a/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkRobotService.kt
+++ b/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkRobotService.kt
@@ -49,8 +49,10 @@ class WechatWorkRobotService @Autowired constructor(
         mentionUsers: List<String> = emptyList()
     ) {
         logger.info("send group msg by robot: $chatId, $content")
+        // mentioned_list 渲染在正文末尾；正文不以换行结尾时 @ 会粘在同一行，补换行以单独成行
+        val finalContent = appendNewlineBeforeMention(content, mentionUsers)
         val msgInfo = MsgInfo(
-            content = content,
+            content = finalContent,
             mentionedList = mentionUsers.ifEmpty { null }
         )
         val msg: Any = if (markerDownFlag) {
@@ -65,6 +67,13 @@ class WechatWorkRobotService @Autowired constructor(
             )
         }
         send(JsonUtil.toJson(msg, false))
+    }
+
+    private fun appendNewlineBeforeMention(content: String, mentionUsers: List<String>): String {
+        if (mentionUsers.isEmpty() || content.endsWith("\n")) {
+            return content
+        }
+        return "$content\n"
     }
 
     companion object {

--- a/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkRobotService.kt
+++ b/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkRobotService.kt
@@ -34,6 +34,14 @@ class WechatWorkRobotService @Autowired constructor(
         }
     }
 
+    /**
+     * 群机器人发消息。
+     *
+     * [mentionUsers] 会写入 webhook text/markdown 的 mentioned_list，用于 @指定成员（userid）。
+     * 后续可扩展（暂未实现）：
+     * - @all：mentioned_list 中增加 "@all"（或 mentioned_mobile_list 中增加 "@all"）
+     * - content 内 @：按企微文档在 content 中拼接 <@userid>（官方 markdown_v2 不支持该语法）
+     */
     fun sendByRobot(
         chatId: String,
         content: String,
@@ -41,20 +49,19 @@ class WechatWorkRobotService @Autowired constructor(
         mentionUsers: List<String> = emptyList()
     ) {
         logger.info("send group msg by robot: $chatId, $content")
+        val msgInfo = MsgInfo(
+            content = content,
+            mentionedList = mentionUsers.ifEmpty { null }
+        )
         val msg: Any = if (markerDownFlag) {
             RobotMarkdownSendMsg(
                 chatId = chatId,
-                markdown = MsgInfo(
-                    content = content
-                )
+                markdown = msgInfo
             )
         } else {
             RobotTextSendMsg(
                 chatId = chatId,
-                text = MsgInfo(
-                    content = content,
-                    mentionedList = mentionUsers
-                )
+                text = msgInfo
             )
         }
         send(JsonUtil.toJson(msg, false))

--- a/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkService.kt
+++ b/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkService.kt
@@ -423,6 +423,14 @@ class WechatWorkService @Autowired constructor(
         }
     }
 
+    /**
+     * 应用号向群聊发消息。
+     *
+     * 非 markdown 时通过 richtext mentioned 节点 @ [mentionUsers]。
+     * 后续可扩展（暂未实现）：
+     * - @all：mentioned 列表增加 "@all" 或等价能力
+     * - markdown 场景的 content 内 <@userid> @成员（当前 markdown 分支尚未带 mention）
+     */
     fun sendByApp(
         chatId: String,
         content: String,

--- a/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkService.kt
+++ b/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkService.kt
@@ -443,8 +443,14 @@ class WechatWorkService @Autowired constructor(
         } else {
             val receiver = Receiver(ReceiverType.group, chatId)
             val richTextContentList = mutableListOf<RichtextContent>()
+            // mentioned 节点接在正文后；正文不以换行结尾时 @ 会粘在同一行，补换行以单独成行
+            val textContent = if (mentionUsers.isNotEmpty() && !content.endsWith("\n")) {
+                "$content\n"
+            } else {
+                content
+            }
             richTextContentList.add(
-                RichtextText(RichtextTextText(content))
+                RichtextText(RichtextTextText(textContent))
             )
             if (mentionUsers.isNotEmpty()) {
                 richTextContentList.add(

--- a/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkService.kt
+++ b/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/WechatWorkService.kt
@@ -426,10 +426,11 @@ class WechatWorkService @Autowired constructor(
     /**
      * 应用号向群聊发消息。
      *
-     * 非 markdown 时通过 richtext mentioned 节点 @ [mentionUsers]。
+     * 通过 richtext mentioned 节点 @ [mentionUsers]（markdown 接口无 mentioned 能力，
+     * 有 @ 需求时同样走 richtext，保证与机器人 mentioned_list 行为一致）。
      * 后续可扩展（暂未实现）：
      * - @all：mentioned 列表增加 "@all" 或等价能力
-     * - markdown 场景的 content 内 <@userid> @成员（当前 markdown 分支尚未带 mention）
+     * - markdown 场景也可改为在 content 中拼接 <@userid>
      */
     fun sendByApp(
         chatId: String,
@@ -438,28 +439,30 @@ class WechatWorkService @Autowired constructor(
         mentionUsers: List<String>
     ) {
         logger.info("send group msg by app: $chatId")
-        if (markerDownFlag) {
-            sendMarkdownGroup(content!!.replace("\\n", "\n"), chatId)
-        } else {
-            val receiver = Receiver(ReceiverType.group, chatId)
-            val richTextContentList = mutableListOf<RichtextContent>()
-            // mentioned 节点接在正文后；正文不以换行结尾时 @ 会粘在同一行，补换行以单独成行
-            val textContent = if (mentionUsers.isNotEmpty() && !content.endsWith("\n")) {
-                "$content\n"
-            } else {
-                content
-            }
-            richTextContentList.add(
-                RichtextText(RichtextTextText(textContent))
-            )
-            if (mentionUsers.isNotEmpty()) {
-                richTextContentList.add(
-                    RichtextMentioned(RichtextMentionedMentioned(mentionUsers))
-                )
-            }
-            val richTextMessage = RichtextMessage(receiver, richTextContentList)
-            sendRichText(richTextMessage)
+        val normalizedContent = content.replace("\\n", "\n")
+        // 无 @ 且为 markdown 时走专用 markdown 接口；需要 @ 审核人时统一走 richtext
+        if (markerDownFlag && mentionUsers.isEmpty()) {
+            sendMarkdownGroup(normalizedContent, chatId)
+            return
         }
+        val receiver = Receiver(ReceiverType.group, chatId)
+        val richTextContentList = mutableListOf<RichtextContent>()
+        // mentioned 节点接在正文后；正文不以换行结尾时 @ 会粘在同一行，补换行以单独成行
+        val textContent = if (mentionUsers.isNotEmpty() && !normalizedContent.endsWith("\n")) {
+            "$normalizedContent\n"
+        } else {
+            normalizedContent
+        }
+        richTextContentList.add(
+            RichtextText(RichtextTextText(textContent))
+        )
+        if (mentionUsers.isNotEmpty()) {
+            richTextContentList.add(
+                RichtextMentioned(RichtextMentionedMentioned(mentionUsers))
+            )
+        }
+        val richTextMessage = RichtextMessage(receiver, richTextContentList)
+        sendRichText(richTextMessage)
     }
 
     // 发送Post请求

--- a/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/model/robot/MsgInfo.kt
+++ b/src/backend/ci/core/common/common-wechatwork/src/main/kotlin/com/tencent/devops/common/wechatwork/model/robot/MsgInfo.kt
@@ -32,9 +32,16 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class MsgInfo(
     val content: String,
 
+    /**
+     * userid 列表，用于 @群成员；传 "@all" 可提醒所有人（暂未在业务侧启用）。
+     * 另可在 content 中使用 <@userid> 语法 @成员（暂未在业务侧启用，markdown_v2 不支持）。
+     */
     @JsonProperty("mentioned_list")
     var mentionedList: List<String>? = mutableListOf(),
 
+    /**
+     * 手机号列表，用于 @对应群成员；同样支持 "@all"（暂未在业务侧启用）。
+     */
     @JsonProperty("mentioned_mobile_list")
     var mentionedMobileList: List<String>? = mutableListOf()
 )

--- a/src/backend/ci/core/notify/biz-notify/src/main/kotlin/com/tencent/devops/notify/service/notifier/WeworkGroupNotifier.kt
+++ b/src/backend/ci/core/notify/biz-notify/src/main/kotlin/com/tencent/devops/notify/service/notifier/WeworkGroupNotifier.kt
@@ -77,6 +77,10 @@ class WeworkGroupNotifier @Autowired constructor(
         val finalBody = NotifierUtils.replaceContentParams(request.bodyParams, rawBody)
 
         val content = finalTitle + "\n\n" + finalBody
+        // mentionReceivers=true 时，将 receivers（如人工审核插件的审核人）写入企微 webhook 的 mentioned_list @成员。
+        // 后续可扩展（暂未实现）：
+        // 1) @all：往 mentioned_list / mentioned_mobile_list 追加 "@all"
+        // 2) content 内 @：企微文档支持在 text/markdown 的 content 中使用 <@userid>（markdown_v2 不支持）
         val mentionUsers = if (request.mentionReceivers == true) {
             request.receivers.toList()
         } else {

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineStageService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineStageService.kt
@@ -38,6 +38,7 @@ import com.tencent.devops.common.event.enums.PipelineBuildStatusBroadCastEventTy
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildQualityCheckBroadCastEvent
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildReviewBroadCastEvent
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildStatusBroadCastEvent
+import com.tencent.devops.common.notify.enums.NotifyType
 import com.tencent.devops.common.notify.utils.NotifyUtils
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ManualReviewAction
@@ -694,6 +695,9 @@ class PipelineStageService @Autowired constructor(
             )
             return
         }
+        val notifyType = NotifyUtils.checkNotifyType(checkIn.notifyType)
+        // 勾选企业微信群消息时，群通知通过 mentioned_list @审核人（与人工审核插件一致）
+        val mentionReceivers = notifyType.contains(NotifyType.WEWORK_GROUP.name)
         pipelineEventDispatcher.dispatch(
             PipelineBuildReviewBroadCastEvent(
                 source = "s(${stage.stageId}) waiting for REVIEW",
@@ -726,9 +730,9 @@ class PipelineStageService @Autowired constructor(
                 position = ControlPointPosition.BEFORE_POSITION,
                 stageSeq = stage.seq,
                 stageId = stage.stageId,
-                notifyType = NotifyUtils.checkNotifyType(checkIn.notifyType),
+                notifyType = notifyType,
                 markdownContent = checkIn.markdownContent,
-                mentionReceivers = true
+                mentionReceivers = mentionReceivers
             )
         )
         // #7971 无指定通知类型时、或者触发人是审核人时，不去通知触发人。

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/ReviewReminderService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/ReviewReminderService.kt
@@ -30,6 +30,7 @@ package com.tencent.devops.process.service
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.event.dispatcher.pipeline.PipelineEventDispatcher
 import com.tencent.devops.process.engine.pojo.event.PipelineBuildReviewReminderEvent
+import com.tencent.devops.common.notify.enums.NotifyType
 import com.tencent.devops.common.notify.utils.NotifyUtils
 import com.tencent.devops.common.pipeline.pojo.element.agent.ManualReviewUserTaskElement
 import com.tencent.devops.common.service.prometheus.BkTimed
@@ -109,6 +110,9 @@ class ReviewReminderService @Autowired constructor(
             null
         }
 
+        val notifyType = NotifyUtils.checkNotifyType(param.notifyType)
+        // 与人工审核插件一致：勾选企业微信群消息时，催审群通知 @审核人
+        val mentionReceivers = notifyType.contains(NotifyType.WEWORK_GROUP.name)
         pipelineEventDispatcher.dispatch(
             PipelineBuildNotifyEvent(
                 notifyTemplateEnum = PipelineNotifyTemplateEnum
@@ -116,7 +120,7 @@ class ReviewReminderService @Autowired constructor(
                 source = "ManualReviewTaskAtom", projectId = projectId, pipelineId = pipelineId,
                 userId = buildTask.starter, buildId = buildId,
                 receivers = reviewUsers.toList(),
-                notifyType = NotifyUtils.checkNotifyType(param.notifyType),
+                notifyType = notifyType,
                 titleParams = mutableMapOf(),
                 bodyParams = mutableMapOf(
                     "title" to notifyTitle,
@@ -139,7 +143,8 @@ class ReviewReminderService @Autowired constructor(
                 ),
                 position = null,
                 stageId = null,
-                markdownContent = param.markdownContent
+                markdownContent = param.markdownContent,
+                mentionReceivers = mentionReceivers
             ),
             this.copy(reminderCount = reminderCount + 1)
         )

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/atom/task/ManualReviewTaskAtom.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/atom/task/ManualReviewTaskAtom.kt
@@ -41,6 +41,7 @@ import com.tencent.devops.common.event.enums.PipelineBuildStatusBroadCastEventTy
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildReviewBroadCastEvent
 import com.tencent.devops.common.event.pojo.pipeline.PipelineBuildStatusBroadCastEvent
 import com.tencent.devops.common.log.utils.BuildLogPrinter
+import com.tencent.devops.common.notify.enums.NotifyType
 import com.tencent.devops.common.notify.utils.NotifyUtils
 import com.tencent.devops.common.pipeline.enums.BuildRecordTimeStamp
 import com.tencent.devops.common.pipeline.enums.BuildStatus
@@ -177,6 +178,9 @@ class ManualReviewTaskAtom(
         val pipelineName = runVariables[PIPELINE_NAME] ?: pipelineId
         val projectName = runVariables[PROJECT_NAME_CHINESE] ?: projectCode
         val buildNum = runVariables[PIPELINE_BUILD_NUM] ?: "1"
+        val notifyType = NotifyUtils.checkNotifyType(param.notifyType)
+        // 勾选企业微信群消息时，群通知通过 mentioned_list @审核人（receivers）
+        val mentionReceivers = notifyType.contains(NotifyType.WEWORK_GROUP.name)
         pipelineEventDispatcher.dispatch(
             PipelineBuildReviewBroadCastEvent(
                 source = "ManualReviewTaskAtom",
@@ -191,7 +195,7 @@ class ManualReviewTaskAtom(
                 source = "ManualReviewTaskAtom", projectId = projectCode, pipelineId = pipelineId,
                 userId = task.starter, buildId = buildId,
                 receivers = reviewUsersList,
-                notifyType = NotifyUtils.checkNotifyType(param.notifyType),
+                notifyType = notifyType,
                 titleParams = mutableMapOf(
                     "content" to notifyTitle
                 ),
@@ -217,7 +221,8 @@ class ManualReviewTaskAtom(
                     "reviewUsers" to reviewUsers,
                     "signature" to ShaUtils.sha256(projectCode + buildId + (param.id ?: "") + appSecret)
                 ),
-                markdownContent = param.markdownContent
+                markdownContent = param.markdownContent,
+                mentionReceivers = mentionReceivers
             )
         )
 


### PR DESCRIPTION
#13382 勾选 WEWORK_GROUP 后通过 mentioned_list 提醒审核人；@all 与 content 内 <@userid> 暂未启用，已在注释中说明后续扩展点。